### PR TITLE
Improve survey editor UX and stabilize 3D demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Guidelines
+
+- Prefer two-space indentation for HTML, CSS, and JavaScript prototypes inside the `dev/` directory.
+- Keep prototype assets self-contained (no new build tooling) and favor vanilla browser APIs.
+- When updating shared themes under `dev/shared/styles/`, document the change in `CHANGELOG.md` and add any follow-up tasks to `TODO.md`.
+- Maintain reverse-chronological ordering in `CHANGELOG.md` entries.
+- Use descriptive bullet lists (not numbered lists) when appending to `TODO.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2024-05-08
+- Added grid-snapped wall and door editing, wall edge labels, and delete-key support to `room_survey_min_v1.html` for a clearer custom-layout workflow.
+- Captured the translucent "glass light" UI treatment as `dev/shared/styles/glass_light_theme.css` and wired it into the first-person 3D demo, along with control tips.
+- Hardened `interactive_3d_room_fps_demo.html` for broader browser compatibility and added Ctrl-drag orbiting while outside walk mode.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+# TODO
+
+- Catalog reusable "glass light" theme tokens for other room survey prototypes and expand the shared theme library as new looks emerge.
+- Evaluate additional camera input affordances (e.g., touch gestures and keyboard shortcuts) for the 3D first-person demo after the next round of feedback.

--- a/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
+++ b/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <title>Interactive 3D Room — First-Person Demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../shared/styles/glass_light_theme.css" />
   <style>
     :root {
       color-scheme: light dark;
@@ -17,8 +18,8 @@
       display: grid;
       grid-template-rows: auto 1fr;
       min-height: 100vh;
-      background: #f5f7fb;
-      color: #1f2933;
+      background: var(--room-ui-bg);
+      color: var(--room-ui-text);
     }
     header {
       display: flex;
@@ -26,8 +27,8 @@
       justify-content: space-between;
       padding: 12px 16px;
       gap: 16px;
-      border-bottom: 1px solid rgba(31,41,51,0.12);
-      background: rgba(255,255,255,0.85);
+      border-bottom: 1px solid var(--room-ui-border);
+      background: var(--room-ui-surface);
       backdrop-filter: blur(6px);
       position: sticky;
       top: 0;
@@ -39,7 +40,7 @@
       flex-wrap: wrap;
     }
     header nav a {
-      color: #2563eb;
+      color: var(--room-ui-link);
       text-decoration: none;
       font-weight: 600;
     }
@@ -56,8 +57,8 @@
       display: grid;
       gap: 16px;
       align-content: start;
-      border-right: 1px solid rgba(31,41,51,0.08);
-      background: rgba(255,255,255,0.8);
+      border-right: 1px solid var(--room-ui-border-soft);
+      background: var(--room-ui-surface);
     }
     aside h2 {
       margin: 0;
@@ -65,7 +66,7 @@
     }
     aside p {
       margin: 0;
-      color: rgba(31,41,51,0.72);
+      color: var(--room-ui-muted-strong);
       font-size: 14px;
       line-height: 1.5;
     }
@@ -87,8 +88,8 @@
       font: inherit;
       padding: 8px 12px;
       border-radius: 6px;
-      border: 1px solid rgba(31,41,51,0.16);
-      background: linear-gradient(180deg, rgba(255,255,255,0.95), rgba(235,239,245,0.95));
+      border: 1px solid var(--room-ui-button-border);
+      background: linear-gradient(180deg, var(--room-ui-button-bg-top), var(--room-ui-button-bg-bottom));
       cursor: pointer;
       transition: transform 120ms ease, box-shadow 120ms ease;
       display: inline-flex;
@@ -98,7 +99,7 @@
     }
     button:hover {
       transform: translateY(-1px);
-      box-shadow: 0 4px 12px rgba(15,23,42,0.12);
+      box-shadow: 0 4px 12px var(--room-ui-shadow);
     }
     button:disabled {
       opacity: 0.6;
@@ -108,7 +109,7 @@
     }
     .viewport {
       position: relative;
-      background: radial-gradient(circle at top, rgba(180,200,230,0.32), transparent 55%), #dfe6f1;
+      background: radial-gradient(circle at top, var(--room-ui-viewport-radial), transparent 55%), var(--room-ui-viewport-bg);
       display: flex;
       align-items: stretch;
       justify-content: center;
@@ -136,14 +137,14 @@
     }
     .overlay .card {
       pointer-events: auto;
-      background: rgba(17,24,39,0.72);
-      color: #f8fafc;
+      background: var(--room-ui-overlay-bg);
+      color: var(--room-ui-overlay-text);
       padding: 18px 20px;
       border-radius: 12px;
       max-width: 320px;
       text-align: center;
       backdrop-filter: blur(10px);
-      box-shadow: 0 12px 40px rgba(15,23,42,0.35);
+      box-shadow: 0 12px 40px var(--room-ui-overlay-shadow);
     }
     .overlay h3 {
       margin: 0 0 8px;
@@ -157,17 +158,24 @@
     .info-box {
       padding: 12px;
       border-radius: 10px;
-      border: 1px solid rgba(31,41,51,0.12);
-      background: rgba(255,255,255,0.7);
+      border: 1px solid var(--room-ui-info-border);
+      background: var(--room-ui-info-bg);
       font-size: 13px;
       line-height: 1.5;
-      color: rgba(31,41,51,0.78);
+      color: var(--room-ui-muted-strong);
+    }
+    .info-box ul {
+      margin: 8px 0 0;
+      padding-left: 18px;
+    }
+    .info-box li {
+      margin: 4px 0;
     }
     .legend {
       display: grid;
       gap: 6px;
       font-size: 13px;
-      color: rgba(31,41,51,0.7);
+      color: var(--room-ui-legend-text);
     }
     .legend span {
       display: inline-flex;
@@ -212,12 +220,20 @@
         <button id="resetWalk">Reset Walk Position</button>
       </div>
       <div class="info-box" id="roomInfo"></div>
+      <div class="info-box">
+        <strong>Controls</strong>
+        <ul>
+          <li>Click <strong>Enter Walk Mode</strong> to lock the pointer, then use <strong>WASD</strong>, the mouse, and <strong>Space</strong>/<strong>Shift</strong>.</li>
+          <li>Hold <strong>Ctrl</strong> and drag in the viewport (while not walking) to orbit the camera and frame the room before entering.</li>
+          <li>Select the sample asset to reveal the move gizmo, then drag the arrows to reposition it on the floor.</li>
+        </ul>
+      </div>
       <div class="legend">
-        <span><span class="swatch" style="background:#d4d8e5"></span> Walls (default thickness 200&nbsp;mm)</span>
-        <span><span class="swatch" style="background:#b49a7a"></span> Custom walls</span>
-        <span><span class="swatch" style="background:#3b8d46"></span> Doors (2.1&nbsp;m tall)</span>
-        <span><span class="swatch" style="background:#2e6fba"></span> Floor items from survey</span>
-        <span><span class="swatch" style="background:#8c5dd8"></span> Loaded X3D asset</span>
+        <span><span class="swatch" style="background:var(--room-ui-legend-wall)"></span> Walls (default thickness 200&nbsp;mm)</span>
+        <span><span class="swatch" style="background:var(--room-ui-legend-custom)"></span> Custom walls</span>
+        <span><span class="swatch" style="background:var(--room-ui-legend-door)"></span> Doors (2.1&nbsp;m tall)</span>
+        <span><span class="swatch" style="background:var(--room-ui-legend-floor)"></span> Floor items from survey</span>
+        <span><span class="swatch" style="background:var(--room-ui-legend-asset)"></span> Loaded X3D asset</span>
       </div>
     </aside>
     <section class="viewport">
@@ -401,8 +417,8 @@
         id: item.id,
         x: toNumber(item.x, layout.room.Wmm / 2),
         y: toNumber(item.y, layout.room.Lmm / 2),
-        w: toNumber(item.w ?? item.size, meta.wmm),
-        l: toNumber(item.l ?? item.size, meta.lmm),
+        w: toNumber(item.w !== undefined ? item.w : item.size, meta.wmm),
+        l: toNumber(item.l !== undefined ? item.l : item.size, meta.lmm),
         rotation: toNumber(item.rotation, 0)
       };
     }
@@ -455,8 +471,10 @@
 
     function ingestLayout(data) {
       if (data.room) {
-        layout.room.Wmm = toNumber(data.room.W ?? data.room.Wmm, layout.room.Wmm);
-        layout.room.Lmm = toNumber(data.room.L ?? data.room.Lmm, layout.room.Lmm);
+        const roomW = data.room.W !== undefined ? data.room.W : data.room.Wmm;
+        const roomL = data.room.L !== undefined ? data.room.L : data.room.Lmm;
+        layout.room.Wmm = toNumber(roomW, layout.room.Wmm);
+        layout.room.Lmm = toNumber(roomL, layout.room.Lmm);
       }
       if (Array.isArray(data.floor_items)) {
         layout.floor_items = data.floor_items.map(normalizeFloorItem);
@@ -489,10 +507,17 @@
       for (let i = group.children.length - 1; i >= 0; i -= 1) {
         const child = group.children[i];
         group.remove(child);
-        if (child.geometry) child.geometry.dispose?.();
+        if (child.geometry && typeof child.geometry.dispose === 'function') {
+          child.geometry.dispose();
+        }
         if (child.material) {
-          if (Array.isArray(child.material)) child.material.forEach(m => m.dispose?.());
-          else child.material.dispose?.();
+          if (Array.isArray(child.material)) {
+            child.material.forEach(m => {
+              if (m && typeof m.dispose === 'function') m.dispose();
+            });
+          } else if (typeof child.material.dispose === 'function') {
+            child.material.dispose();
+          }
         }
       }
     }
@@ -519,6 +544,8 @@
       const minZ = -floorL / 2 + 0.25;
       const maxZ = floorL / 2 - 0.25;
       walkBounds = { minX, maxX, minZ, maxZ, minY: 0.1, maxY: mm2m(ROOM_HEIGHT_MM) - 0.2 };
+      const midHeight = (walkBounds.maxY + walkBounds.minY) / 2;
+      orbitTarget.set(0, midHeight, 0);
     }
 
     function buildWalls() {
@@ -599,7 +626,7 @@
         const meta = FLOOR_ITEM_META[item.type] || FLOOR_ITEM_META.floorBox;
         const w = mm2m(toNumber(item.w, meta.wmm));
         const l = mm2m(toNumber(item.l, meta.lmm));
-        const h = meta.height ?? 1.0;
+        const h = meta.height !== undefined ? meta.height : 1.0;
         const geometry = new THREE.BoxGeometry(w, h, l);
         const material = new THREE.MeshStandardMaterial({ color: meta.color, roughness: 0.45, metalness: 0.1 });
         const mesh = new THREE.Mesh(geometry, material);
@@ -615,9 +642,9 @@
       const Wm = (layout.room.Wmm / 1000).toFixed(2);
       const Lm = (layout.room.Lmm / 1000).toFixed(2);
       const heightM = (ROOM_HEIGHT_MM / 1000).toFixed(2);
-      const customCount = layout.custom_walls?.length ?? 0;
-      const doorCount = layout.doors?.length ?? 0;
-      const itemCount = layout.floor_items?.length ?? 0;
+      const customCount = layout.custom_walls && layout.custom_walls.length ? layout.custom_walls.length : 0;
+      const doorCount = layout.doors && layout.doors.length ? layout.doors.length : 0;
+      const itemCount = layout.floor_items && layout.floor_items.length ? layout.floor_items.length : 0;
       roomInfo.innerHTML = `Room: <strong>${Wm}m × ${Lm}m</strong> &middot; Height ${heightM}m<br>` +
         `${customCount} custom wall${customCount === 1 ? '' : 's'}, ${doorCount} door${doorCount === 1 ? '' : 's'}, ${itemCount} floor item${itemCount === 1 ? '' : 's'}`;
     }
@@ -715,7 +742,9 @@
 
     transformControls.addEventListener('objectChange', () => {
       if (!selectedObject) return;
-      const baseY = selectedObject.userData.baseY ?? selectedObject.position.y;
+      const baseY = selectedObject.userData && selectedObject.userData.baseY !== undefined
+        ? selectedObject.userData.baseY
+        : selectedObject.position.y;
       selectedObject.position.y = baseY;
       clampAsset(selectedObject);
     });
@@ -731,7 +760,9 @@
       const radius = Math.max(assetSize.x, assetSize.z) / 2;
       const targetX = clamp(0, walkBounds.minX + radius, walkBounds.maxX - radius);
       const targetZ = clamp(0, walkBounds.minZ + radius, walkBounds.maxZ - radius);
-      const baseY = assetAnchor.userData.baseY ?? assetAnchor.position.y;
+      const baseY = assetAnchor.userData && assetAnchor.userData.baseY !== undefined
+        ? assetAnchor.userData.baseY
+        : assetAnchor.position.y;
       assetAnchor.position.set(targetX, baseY, targetZ);
       clampAsset(assetAnchor);
     }
@@ -749,9 +780,12 @@
 
     const raycaster = new THREE.Raycaster();
     const pointer = new THREE.Vector2();
+    const orbitTarget = new THREE.Vector3(0, 1.6, 0);
+    let orbitState = null;
 
     function onPointerDown(event) {
       if (pointerControls.isLocked) return;
+      if (event.ctrlKey) return;
       const rect = renderer.domElement.getBoundingClientRect();
       pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
       pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
@@ -764,7 +798,70 @@
       }
     }
 
-    renderer.domElement.addEventListener('pointerdown', onPointerDown);
+    function beginOrbit(event) {
+      const holder = pointerControls.getObject();
+      const offset = holder.position.clone().sub(orbitTarget);
+      const spherical = new THREE.Spherical();
+      spherical.setFromVector3(offset);
+      orbitState = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        spherical
+      };
+      if (renderer.domElement.setPointerCapture) {
+        renderer.domElement.setPointerCapture(event.pointerId);
+      }
+    }
+
+    function updateOrbit(event) {
+      if (!orbitState) return;
+      const deltaX = event.clientX - orbitState.startX;
+      const deltaY = event.clientY - orbitState.startY;
+      const spherical = orbitState.spherical.clone();
+      spherical.theta -= deltaX * 0.005;
+      spherical.phi = clamp(spherical.phi + deltaY * 0.003, 0.1, Math.PI - 0.1);
+      const radius = Math.max(1.2, spherical.radius);
+      spherical.radius = radius;
+      const offset = new THREE.Vector3().setFromSpherical(spherical);
+      const holder = pointerControls.getObject();
+      holder.position.copy(orbitTarget.clone().add(offset));
+      holder.lookAt(orbitTarget);
+      camera.position.set(0, 0, 0);
+      camera.rotation.set(0, 0, 0);
+      orbitState.startX = event.clientX;
+      orbitState.startY = event.clientY;
+      orbitState.spherical = spherical;
+    }
+
+    function endOrbit(event) {
+      if (!orbitState || orbitState.pointerId !== event.pointerId) return;
+      if (renderer.domElement.releasePointerCapture) {
+        try {
+          renderer.domElement.releasePointerCapture(event.pointerId);
+        } catch (err) {}
+      }
+      orbitState = null;
+    }
+
+    function onViewportPointerDown(event) {
+      if (pointerControls.isLocked) return;
+      if (event.ctrlKey) {
+        beginOrbit(event);
+        event.preventDefault();
+        return;
+      }
+      onPointerDown(event);
+    }
+
+    renderer.domElement.addEventListener('pointerdown', onViewportPointerDown);
+    renderer.domElement.addEventListener('pointermove', event => {
+      if (orbitState) {
+        updateOrbit(event);
+      }
+    });
+    renderer.domElement.addEventListener('pointerup', endOrbit);
+    renderer.domElement.addEventListener('pointercancel', endOrbit);
 
     function resetLayout() {
       layout.room.Wmm = 6000;
@@ -805,7 +902,8 @@
     focusAssetBtn.addEventListener('click', () => focusOnAsset());
 
     layoutImport.addEventListener('change', event => {
-      const file = event.target.files?.[0];
+      const files = event.target && event.target.files;
+      const file = files && files[0];
       if (!file) return;
       const reader = new FileReader();
       reader.onload = e => {

--- a/dev/room_survey_min/room_survey_min_v1.html
+++ b/dev/room_survey_min/room_survey_min_v1.html
@@ -20,6 +20,11 @@
     .handle { fill: #fff; stroke: #333; stroke-width: 1.5; cursor: pointer; }
     .custom-wall-line { cursor: move; }
     #roomRect.floor-selected { stroke: #1976d2; stroke-width: 3; }
+    .wall-label { font-size: 12px; font-weight: 600; fill: #111; pointer-events: none; }
+    .selected-door { stroke: #26a69a !important; }
+    .selected-wall-item rect { stroke: #1976d2 !important; }
+    .selected-wall-item line { stroke: #1976d2 !important; }
+    .selected-floor-item rect { stroke: #1976d2 !important; stroke-width: 3 !important; }
     body[data-mode="basic"] .custom-only { display: none !important; }
     body[data-mode="custom"] .basic-only { display: none !important; }
     body[data-mode="basic"] .wall-choice { display: none !important; }
@@ -91,6 +96,7 @@
 
   <!-- Draggable items -->
   <g id="baseWallsOverlay"></g>
+  <g id="wallLabels"></g>
   <g id="selectionOverlay"></g>
   <g id="customWalls"></g>
   <g id="doorsLayer"></g>
@@ -138,6 +144,7 @@ const roomRect = document.getElementById('roomRect');
 const originDot = document.getElementById('origin');
 const gridG = document.getElementById('grid');
 const baseWallsG = document.getElementById('baseWallsOverlay');
+const wallLabelsG = document.getElementById('wallLabels');
 const selectionG = document.getElementById('selectionOverlay');
 const customWallsG = document.getElementById('customWalls');
 const doorsG = document.getElementById('doorsLayer');
@@ -190,6 +197,10 @@ function snapValue(vmm) {
 }
 
 function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
+
+function snapPoint(pt) {
+  return { x: snapValue(pt.x), y: snapValue(pt.y) };
+}
 
 function recomputeScale() {
   const maxWpx = 800, maxLpx = 520;
@@ -442,9 +453,26 @@ function clampStateToRoom() {
 function defaultHudMessage() {
   const snapStr = `Snap: ${state.snap} mm` + (state.imperial ? ` (${mmToIn(state.snap).toFixed(2)} in)` : '');
   let sel = 'Floor';
-  if (state.selectedSurface?.type === 'wall') {
-    const geom = getWallGeometry(state.selectedSurface.ref);
+  const surface = state.selectedSurface;
+  if (surface?.type === 'wall') {
+    const geom = getWallGeometry(surface.ref);
     sel = geom ? geom.label : 'Wall';
+  } else if (surface?.type === 'floorItem') {
+    const item = state.floorItems.find(f => f.id === surface.id);
+    const def = item ? FLOOR_ITEM_DEFS[item.type] || FLOOR_ITEM_DEFS.floorBox : null;
+    sel = def ? def.label : 'Floor item';
+  } else if (surface?.type === 'wallItem') {
+    const item = state.wallItems.find(w => w.id === surface.id);
+    if (item?.type === 'socket') {
+      const geom = getWallGeometry(item.wall);
+      sel = geom ? `Socket on ${geom.label}` : 'Socket';
+    } else {
+      sel = 'Wall item';
+    }
+  } else if (surface?.type === 'door') {
+    const door = state.doors.find(d => d.id === surface.id);
+    const geom = door ? getWallGeometry(door.wall) : null;
+    sel = geom ? `Door on ${geom.label}` : 'Door';
   }
   return `${snapStr} | Selected: ${sel}`;
 }
@@ -452,6 +480,7 @@ function defaultHudMessage() {
 function render() {
   updateWallSelect();
   renderBaseWallsOverlay();
+  renderWallLabels();
   renderCustomWalls();
   renderDoors();
   renderWallItems();
@@ -489,12 +518,48 @@ function renderBaseWallsOverlay() {
   });
 }
 
+function renderWallLabels() {
+  wallLabelsG.innerHTML = '';
+  baseWallDefinitions().forEach((w, idx) => {
+    const geom = enrichWallGeometry(w);
+    if (!geom) return;
+    const mid = {
+      x: (geom.start.x + geom.end.x) / 2,
+      y: (geom.start.y + geom.end.y) / 2
+    };
+    const offsetMm = (geom.thickness || BASE_WALL_THICKNESS) / 2 + 400;
+    const labelPt = {
+      x: mid.x - geom.normal.x * offsetMm,
+      y: mid.y - geom.normal.y * offsetMm
+    };
+    const [lx, ly] = mmToPx(labelPt.x, labelPt.y);
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    text.setAttribute('x', lx);
+    text.setAttribute('y', ly);
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('alignment-baseline', 'middle');
+    text.classList.add('wall-label');
+    text.textContent = w.label || `Wall ${idx + 1}`;
+    wallLabelsG.appendChild(text);
+  });
+}
+
 function renderSelection() {
   selectionG.innerHTML = '';
   const isFloor = state.selectedSurface?.type === 'floor';
   roomRect.classList.toggle('floor-selected', !!isFloor);
+  let wallRef = null;
   if (state.selectedSurface?.type === 'wall') {
-    const geom = getWallGeometry(state.selectedSurface.ref);
+    wallRef = state.selectedSurface.ref;
+  } else if (state.selectedSurface?.type === 'wallItem') {
+    const item = state.wallItems.find(w => w.id === state.selectedSurface.id);
+    wallRef = item?.wall;
+  } else if (state.selectedSurface?.type === 'door') {
+    const door = state.doors.find(d => d.id === state.selectedSurface.id);
+    wallRef = door?.wall;
+  }
+  if (wallRef) {
+    const geom = getWallGeometry(wallRef);
     if (!geom) return;
     const start = mmToPx(geom.start.x, geom.start.y);
     const end = mmToPx(geom.end.x, geom.end.y);
@@ -572,6 +637,9 @@ function renderDoors() {
     line.setAttribute('stroke-linecap', 'butt');
     line.dataset.doorId = door.id;
     line.addEventListener('pointerdown', handleDoorDragStart);
+    if (state.selectedSurface?.type === 'door' && state.selectedSurface.id === door.id) {
+      line.classList.add('selected-door');
+    }
     doorsG.appendChild(line);
   });
 }
@@ -606,6 +674,10 @@ function renderWallItems() {
     line.dataset.wallItemId = it.id;
     line.addEventListener('pointerdown', handleSocketHeightDragStart);
 
+    if (state.selectedSurface?.type === 'wallItem' && state.selectedSurface.id === it.id) {
+      g.classList.add('selected-wall-item');
+    }
+
     g.appendChild(line);
     g.appendChild(mk);
     wallItemsG.appendChild(g);
@@ -636,6 +708,9 @@ function renderFloorItems() {
     rect.setAttribute('fill-opacity', 0.45);
     rect.setAttribute('stroke', def.stroke);
     rect.setAttribute('stroke-width', 2);
+    if (state.selectedSurface?.type === 'floorItem' && state.selectedSurface.id === item.id) {
+      group.classList.add('selected-floor-item');
+    }
     group.appendChild(rect);
 
     const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
@@ -659,6 +734,7 @@ function handleFloorDragStart(evt) {
   if (!item) return;
   const pt = svgPoint(evt);
   const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
+  setSelectedSurface({ type: 'floorItem', id }, { skipRender: true });
   drag = {
     kind: 'floor',
     id,
@@ -675,6 +751,7 @@ function handleSocketAlongDragStart(evt) {
   const id = evt.currentTarget.dataset.wallItemId;
   const item = state.wallItems.find(w => w.id === id);
   if (!item) return;
+  setSelectedSurface({ type: 'wallItem', id }, { skipRender: true });
   drag = { kind: 'socketS', id, captureEl: svg, pointerId: evt.pointerId };
   svg.setPointerCapture(evt.pointerId);
   evt.preventDefault();
@@ -684,6 +761,7 @@ function handleSocketHeightDragStart(evt) {
   const id = evt.currentTarget.dataset.wallItemId;
   const item = state.wallItems.find(w => w.id === id);
   if (!item) return;
+  setSelectedSurface({ type: 'wallItem', id }, { skipRender: true });
   drag = { kind: 'socketH', id, captureEl: svg, pointerId: evt.pointerId };
   svg.setPointerCapture(evt.pointerId);
   evt.preventDefault();
@@ -697,10 +775,11 @@ function handleCustomWallLineDown(evt) {
   if (!wall) return;
   const pt = svgPoint(evt);
   const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
+  const snapped = snapPoint(roomPt);
   drag = {
     kind: 'wall-move',
     wallId,
-    start: roomPt,
+    start: snapped,
     orig: { x1: wall.x1, y1: wall.y1, x2: wall.x2, y2: wall.y2 },
     captureEl: svg,
     pointerId: evt.pointerId
@@ -717,6 +796,7 @@ function handleWallHandleDown(evt) {
   setSelectedSurface({ type: 'wall', ref: `custom:${wallId}` }, { skipRender: true });
   const pt = svgPoint(evt);
   const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
+  const snapped = snapPoint(roomPt);
   drag = {
     kind: 'wall-handle',
     wallId,
@@ -724,7 +804,7 @@ function handleWallHandleDown(evt) {
     captureEl: svg,
     pointerId: evt.pointerId
   };
-  drag.start = roomPt;
+  drag.start = snapped;
   svg.setPointerCapture(evt.pointerId);
   evt.preventDefault();
 }
@@ -733,7 +813,7 @@ function handleDoorDragStart(evt) {
   const id = evt.currentTarget.dataset.doorId;
   const door = state.doors.find(d => d.id === id);
   if (!door) return;
-  setSelectedSurface({ type: 'wall', ref: door.wall }, { skipRender: true });
+  setSelectedSurface({ type: 'door', id }, { skipRender: true });
   drag = { kind: 'door', id, captureEl: svg, pointerId: evt.pointerId };
   svg.setPointerCapture(evt.pointerId);
   evt.preventDefault();
@@ -776,21 +856,27 @@ document.addEventListener('pointermove', evt => {
     if (!wall) return;
     const dx = roomPt.x - drag.start.x;
     const dy = roomPt.y - drag.start.y;
-    wall.x1 = clamp(drag.orig.x1 + dx, 0, state.Wmm);
-    wall.y1 = clamp(drag.orig.y1 + dy, 0, state.Lmm);
-    wall.x2 = clamp(drag.orig.x2 + dx, 0, state.Wmm);
-    wall.y2 = clamp(drag.orig.y2 + dy, 0, state.Lmm);
+    const start = snapPoint({ x: drag.orig.x1 + dx, y: drag.orig.y1 + dy });
+    const end = snapPoint({ x: drag.orig.x2 + dx, y: drag.orig.y2 + dy });
+    const clampStart = clampPointToRoom(start);
+    const clampEnd = clampPointToRoom(end);
+    wall.x1 = clampStart.x;
+    wall.y1 = clampStart.y;
+    wall.x2 = clampEnd.x;
+    wall.y2 = clampEnd.y;
     showHud(`Moved ${wall.name || 'custom wall'}`);
     render();
   } else if (drag.kind === 'wall-handle') {
     const wall = getCustomWallById(drag.wallId);
     if (!wall) return;
+    const snapped = snapPoint(roomPt);
+    const clamped = clampPointToRoom(snapped);
     if (drag.handle === 'start') {
-      wall.x1 = roomPt.x;
-      wall.y1 = roomPt.y;
+      wall.x1 = clamped.x;
+      wall.y1 = clamped.y;
     } else {
-      wall.x2 = roomPt.x;
-      wall.y2 = roomPt.y;
+      wall.x2 = clamped.x;
+      wall.y2 = clamped.y;
     }
     showHud(`Reshaping ${wall.name || 'custom wall'}`);
     render();
@@ -801,7 +887,9 @@ document.addEventListener('pointermove', evt => {
     if (!geom) return;
     const proj = projectPointOntoWall(geom, roomPt);
     const half = door.width / 2;
-    const center = clamp(proj.s, half, Math.max(half, geom.length - half));
+    const maxCenter = Math.max(half, geom.length - half);
+    const centerSnapped = snapValue(proj.s);
+    const center = clamp(centerSnapped, half, maxCenter);
     door.offset = clamp(center - half, 0, Math.max(0, geom.length - door.width));
     showHud(`Door position ${fmtLen(center)} along ${geom.label}`);
     render();
@@ -817,17 +905,68 @@ document.addEventListener('pointerup', evt => {
   drag = null;
 });
 
+function deleteSelectedItem() {
+  const surface = state.selectedSurface;
+  if (!surface) return null;
+  if (surface.type === 'floorItem') {
+    const idx = state.floorItems.findIndex(f => f.id === surface.id);
+    if (idx >= 0) {
+      const [removed] = state.floorItems.splice(idx, 1);
+      const def = removed ? FLOOR_ITEM_DEFS[removed.type] || FLOOR_ITEM_DEFS.floorBox : null;
+      setSelectedSurface({ type: 'floor' }, { skipRender: true });
+      return `${def ? def.label : 'Floor item'} removed`;
+    }
+  } else if (surface.type === 'wallItem') {
+    const idx = state.wallItems.findIndex(w => w.id === surface.id);
+    if (idx >= 0) {
+      const [removed] = state.wallItems.splice(idx, 1);
+      const geom = removed ? getWallGeometry(removed.wall) : null;
+      setSelectedSurface(removed ? { type: 'wall', ref: removed.wall } : { type: 'floor' }, { skipRender: true });
+      return `Wall item removed${geom ? ` from ${geom.label}` : ''}`;
+    }
+  } else if (surface.type === 'door') {
+    const idx = state.doors.findIndex(d => d.id === surface.id);
+    if (idx >= 0) {
+      const [removed] = state.doors.splice(idx, 1);
+      const geom = removed ? getWallGeometry(removed.wall) : null;
+      setSelectedSurface(removed ? { type: 'wall', ref: removed.wall } : { type: 'floor' }, { skipRender: true });
+      return `Door removed${geom ? ` from ${geom.label}` : ''}`;
+    }
+  } else if (surface.type === 'wall' && typeof surface.ref === 'string' && surface.ref.startsWith('custom:')) {
+    const id = surface.ref.split(':')[1];
+    const idx = state.customWalls.findIndex(w => String(w.id) === id);
+    if (idx >= 0) {
+      const [removed] = state.customWalls.splice(idx, 1);
+      state.doors = state.doors.filter(d => d.wall !== surface.ref);
+      state.wallItems = state.wallItems.filter(it => it.wall !== surface.ref);
+      setSelectedSurface({ type: 'floor' }, { skipRender: true });
+      return `${removed?.name || 'Custom wall'} removed`;
+    }
+  }
+  return null;
+}
+
+document.addEventListener('keydown', evt => {
+  if (evt.key !== 'Delete' && evt.key !== 'Backspace') return;
+  const message = deleteSelectedItem();
+  if (message) {
+    evt.preventDefault();
+    showHud(message);
+    render();
+  }
+});
+
 svg.addEventListener('pointerdown', evt => {
   if (!drawWallState || state.mode !== 'custom') return;
   if (evt.target.closest('[data-floor-item-id],[data-wall-item-id],[data-door-id],[data-wall-id]')) return;
   const pt = svgPoint(evt);
   const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
   if (!drawWallState.start) {
-    drawWallState.start = roomPt;
+    drawWallState.start = snapPoint(roomPt);
     showHud('Select second point for new wall');
   } else {
     const start = drawWallState.start;
-    const end = roomPt;
+    const end = snapPoint(roomPt);
     if (Math.hypot(end.x - start.x, end.y - start.y) > 10) {
       const wall = {
         id: genId('wall'),
@@ -846,6 +985,12 @@ svg.addEventListener('pointerdown', evt => {
   }
   evt.preventDefault();
   render();
+});
+
+svg.addEventListener('pointerdown', evt => {
+  if (drawWallState && state.mode === 'custom') return;
+  if (evt.target.closest('[data-floor-item-id],[data-wall-item-id],[data-door-id],[data-wall-id],[data-wall-ref]')) return;
+  setSelectedSurface({ type: 'floor' });
 });
 
 roomRect.addEventListener('pointerdown', evt => {
@@ -892,6 +1037,7 @@ basicAddBtn.addEventListener('click', () => {
     rotation: 0
   };
   state.floorItems.push(item);
+  setSelectedSurface({ type: 'floorItem', id: item.id });
   showHud(`${def.label} added`);
   render();
 });
@@ -908,7 +1054,7 @@ addBtn.addEventListener('click', () => {
     const s = snapValue(geom.length / 2);
     const item = { id: genId('socket'), type: 'socket', wall: wallRef, s, h: snapValue(300) };
     state.wallItems.push(item);
-    setSelectedSurface({ type: 'wall', ref: wallRef });
+    setSelectedSurface({ type: 'wallItem', id: item.id });
     showHud(`Socket added to ${geom.label}`);
     render();
   } else {
@@ -923,7 +1069,7 @@ addBtn.addEventListener('click', () => {
       rotation: 0
     };
     state.floorItems.push(item);
-    setSelectedSurface({ type: 'floor' });
+    setSelectedSurface({ type: 'floorItem', id: item.id });
     showHud(`${def.label} added`);
     render();
   }
@@ -962,7 +1108,7 @@ addDoorBtn.addEventListener('click', () => {
     thickness: DOOR_DEFAULT_THICKNESS
   };
   state.doors.push(door);
-  setSelectedSurface({ type: 'wall', ref: geom.ref });
+  setSelectedSurface({ type: 'door', id: door.id });
   showHud(`Door added to ${geom.label}`);
   render();
 });

--- a/dev/shared/styles/glass_light_theme.css
+++ b/dev/shared/styles/glass_light_theme.css
@@ -1,0 +1,27 @@
+:root {
+  --room-ui-bg: #f5f7fb;
+  --room-ui-text: #1f2933;
+  --room-ui-muted: rgba(31,41,51,0.68);
+  --room-ui-muted-strong: rgba(31,41,51,0.72);
+  --room-ui-surface: rgba(255,255,255,0.85);
+  --room-ui-border: rgba(31,41,51,0.12);
+  --room-ui-border-soft: rgba(31,41,51,0.08);
+  --room-ui-link: #2563eb;
+  --room-ui-button-border: rgba(31,41,51,0.16);
+  --room-ui-button-bg-top: rgba(255,255,255,0.95);
+  --room-ui-button-bg-bottom: rgba(235,239,245,0.95);
+  --room-ui-shadow: rgba(15,23,42,0.12);
+  --room-ui-overlay-bg: rgba(17,24,39,0.72);
+  --room-ui-overlay-text: #f8fafc;
+  --room-ui-overlay-shadow: rgba(15,23,42,0.35);
+  --room-ui-info-bg: rgba(255,255,255,0.7);
+  --room-ui-info-border: rgba(31,41,51,0.12);
+  --room-ui-legend-text: rgba(31,41,51,0.7);
+  --room-ui-legend-wall: #d4d8e5;
+  --room-ui-legend-custom: #b49a7a;
+  --room-ui-legend-door: #3b8d46;
+  --room-ui-legend-floor: #2e6fba;
+  --room-ui-legend-asset: #8c5dd8;
+  --room-ui-viewport-bg: #dfe6f1;
+  --room-ui-viewport-radial: rgba(180,200,230,0.32);
+}


### PR DESCRIPTION
## Summary
- add wall labels, grid-snapped editing, and delete-key support to the v1 room survey prototype
- capture the translucent "glass light" visual theme for reuse and wire it into the first-person demo with new control tips
- document shared guidelines via AGENTS/TODO/CHANGELOG for future theme and prototype iterations

## Testing
- not run (static front-end changes)


------
https://chatgpt.com/codex/tasks/task_e_68deeb51a6888329b91ab13e4a238315