### PR TITLE
Unify prototype navigation and preload room defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2024-05-09
+- Added a shared landing page and unified navigation styling across the survey, orbit, and first-person demos using the glass light theme.
+- Preloaded the microscope room layout across 2D and 3D experiences, preventing delete-key conflicts while editing form controls.
+- Synced the first-person demo with the default preset and cleared selections when importing or resetting layouts for smoother testing.
+
 ## 2024-05-08
 - Added grid-snapped wall and door editing, wall edge labels, and delete-key support to `room_survey_min_v1.html` for a clearer custom-layout workflow.
 - Captured the translucent "glass light" UI treatment as `dev/shared/styles/glass_light_theme.css` and wired it into the first-person 3D demo, along with control tips.

--- a/dev/index.html
+++ b/dev/index.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Room Survey Prototype Suite</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="shared/styles/glass_light_theme.css" />
+  <style>
+    :root {
+      color-scheme: light;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+      background: var(--room-ui-bg);
+      color: var(--room-ui-text);
+      display: grid;
+      grid-template-rows: auto 1fr;
+      min-height: 100vh;
+    }
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 14px 20px;
+      gap: 16px;
+      border-bottom: 1px solid var(--room-ui-border);
+      background: var(--room-ui-surface);
+      backdrop-filter: blur(6px);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+    header .subtitle {
+      font-size: 13px;
+      color: var(--room-ui-muted-strong);
+      margin-top: 2px;
+    }
+    nav {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .nav-link {
+      color: var(--room-ui-link);
+      text-decoration: none;
+      font-weight: 600;
+      padding: 6px 10px;
+      border-radius: 6px;
+      transition: background 120ms ease, color 120ms ease;
+    }
+    .nav-link:hover {
+      background: rgba(37, 99, 235, 0.12);
+    }
+    .nav-link.active {
+      background: rgba(37, 99, 235, 0.18);
+    }
+    main {
+      padding: 32px 24px 48px;
+      display: grid;
+      gap: 28px;
+      max-width: 1120px;
+      width: 100%;
+      margin: 0 auto;
+    }
+    .intro {
+      display: grid;
+      gap: 12px;
+      background: var(--room-ui-surface);
+      border-radius: 16px;
+      padding: 24px;
+      border: 1px solid var(--room-ui-border-soft);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    }
+    .intro p {
+      margin: 0;
+      color: var(--room-ui-muted-strong);
+      font-size: 15px;
+      line-height: 1.55;
+    }
+    .cards {
+      display: grid;
+      gap: 20px;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+    .card {
+      background: var(--room-ui-surface);
+      border-radius: 16px;
+      padding: 20px;
+      border: 1px solid var(--room-ui-border-soft);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+      display: grid;
+      gap: 12px;
+    }
+    .card h2 {
+      margin: 0;
+      font-size: 20px;
+    }
+    .card p {
+      margin: 0;
+      color: var(--room-ui-muted);
+      font-size: 14px;
+      line-height: 1.55;
+    }
+    .cta {
+      align-self: start;
+      appearance: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 1px solid var(--room-ui-button-border);
+      background: linear-gradient(180deg, var(--room-ui-button-bg-top), var(--room-ui-button-bg-bottom));
+      color: var(--room-ui-link);
+      font-weight: 600;
+      text-decoration: none;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+    .cta:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 16px var(--room-ui-shadow);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <strong>Room Survey Prototype Suite</strong>
+      <div class="subtitle">Navigate between the 2D editor, orbiting viewer, and first-person walkthrough.</div>
+    </div>
+    <nav>
+      <a class="nav-link active" href="index.html">Home</a>
+      <a class="nav-link" href="room_survey_min/room_survey_min_v1.html">2D Survey</a>
+      <a class="nav-link" href="interactive_3d_room/interactive_3d_room_v1.html">Orbit Viewer</a>
+      <a class="nav-link" href="interactive_3d_room/interactive_3d_room_fps_demo.html">First-Person Demo</a>
+    </nav>
+  </header>
+  <main>
+    <section class="intro">
+      <h1>Coordinate microscope room planning</h1>
+      <p>Use these prototypes to capture a room’s dimensions, keep track of microscope peripherals, and validate the layout in 3D. Start with the top-down survey, then export and inspect the space with the orbit and first-person viewers.</p>
+    </section>
+    <section class="cards">
+      <article class="card">
+        <h2>2D Room Survey</h2>
+        <p>Define room bounds, drag equipment and sockets with grid snapping, export JSON, and hand off the plan for 3D review.</p>
+        <a class="cta" href="room_survey_min/room_survey_min_v1.html">Open 2D Survey</a>
+      </article>
+      <article class="card">
+        <h2>Interactive Orbit Viewer</h2>
+        <p>Import survey exports, extrude walls, doors, and floor items, and orbit around the layout to verify placement in 3D.</p>
+        <a class="cta" href="interactive_3d_room/interactive_3d_room_v1.html">Launch Orbit Viewer</a>
+      </article>
+      <article class="card">
+        <h2>First-Person Walkthrough</h2>
+        <p>Walk through the room with WASD controls, drag sample assets, and evaluate clearances using the imported survey geometry.</p>
+        <a class="cta" href="interactive_3d_room/interactive_3d_room_fps_demo.html">Enter Walkthrough</a>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
+++ b/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
@@ -39,13 +39,19 @@
       gap: 12px;
       flex-wrap: wrap;
     }
-    header nav a {
+    .nav-link {
       color: var(--room-ui-link);
       text-decoration: none;
       font-weight: 600;
+      padding: 6px 10px;
+      border-radius: 6px;
+      transition: background 120ms ease, color 120ms ease;
     }
-    header nav a:hover {
-      text-decoration: underline;
+    .nav-link:hover {
+      background: rgba(37, 99, 235, 0.12);
+    }
+    .nav-link.active {
+      background: rgba(37, 99, 235, 0.18);
     }
     main {
       display: grid;
@@ -194,11 +200,13 @@
   <header>
     <div>
       <strong>3D Room Viewer — First-Person Prototype</strong>
-      <div style="font-size:13px;color:rgba(31,41,51,0.68);">Walk inside the imported room layout, experiment with the FreeCAD X3D asset, and preview placement in 3D.</div>
+      <div style="font-size:13px;color:rgba(31,41,51,0.68);">Walk inside the imported room layout, experiment with the FreeCAD <em>dozenSidedStack</em> sample, and preview placement in 3D.</div>
     </div>
     <nav>
-      <a href="../room_survey_min/room_survey_min_v1.html">2D Room Survey</a>
-      <a href="interactive_3d_room_v1.html">Orbit Viewer</a>
+      <a class="nav-link" href="../index.html">Home</a>
+      <a class="nav-link" href="../room_survey_min/room_survey_min_v1.html">2D Survey</a>
+      <a class="nav-link" href="interactive_3d_room_v1.html">Orbit Viewer</a>
+      <a class="nav-link active" href="interactive_3d_room_fps_demo.html">First-Person Demo</a>
     </nav>
   </header>
   <main>
@@ -271,6 +279,22 @@
       table: { label: 'Table', wmm: 1800, lmm: 900, color: 0x3956b5, height: 0.9 },
       pump: { label: 'Pump', wmm: 1200, lmm: 600, color: 0xeb7127, height: 0.8 }
     };
+
+    const DEFAULT_ROOM_PRESET = () => ({
+      room: { W: 6000, L: 8000 },
+      floor_items: [
+        { type: 'microscope', x: 2200, y: 5200, rotation: 0 },
+        { type: 'table', x: 3800, y: 5200, rotation: 0 },
+        { type: 'pump', x: 4200, y: 3400, rotation: 0 },
+        { type: 'floorBox', x: 3000, y: 3600, rotation: 0 }
+      ],
+      wall_items: [
+        { type: 'socket', wall: 'base:1', s: 1500, h: 300 },
+        { type: 'socket', wall: 'base:3', s: 4500, h: 300 }
+      ],
+      custom_walls: [],
+      doors: []
+    });
 
     const layout = {
       room: { Wmm: 6000, Lmm: 8000 },
@@ -495,6 +519,7 @@
       }
       ensureLayoutIds();
       applyLayout();
+      selectObject(null);
     }
 
     function mmPointToWorld(xMm, yMm) {
@@ -864,13 +889,15 @@
     renderer.domElement.addEventListener('pointercancel', endOrbit);
 
     function resetLayout() {
-      layout.room.Wmm = 6000;
-      layout.room.Lmm = 8000;
-      layout.floor_items = [];
-      layout.wall_items = [];
-      layout.custom_walls = [];
-      layout.doors = [];
+      const preset = DEFAULT_ROOM_PRESET();
+      layout.room.Wmm = preset.room.W;
+      layout.room.Lmm = preset.room.L;
+      layout.floor_items = (preset.floor_items || []).map(normalizeFloorItem);
+      layout.wall_items = (preset.wall_items || []).map(normalizeWallItem);
+      layout.custom_walls = (preset.custom_walls || []).map(normalizeCustomWall);
+      layout.doors = (preset.doors || []).map(normalizeDoor);
       applyLayout();
+      selectObject(null);
     }
 
     function focusOnAsset() {

--- a/dev/interactive_3d_room/interactive_3d_room_v1.html
+++ b/dev/interactive_3d_room/interactive_3d_room_v1.html
@@ -1,98 +1,242 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <!-- Prototype version 1 of the interactive 3D room viewer -->
   <meta charset="utf-8" />
-  <title>Interactive 3D Room (X3DOM) — Width/Length + Triangle XY — v1</title>
+  <title>Interactive 3D Room (Orbit Viewer)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="https://www.x3dom.org/release/x3dom.css">
+  <link rel="stylesheet" href="../shared/styles/glass_light_theme.css" />
   <script src="https://www.x3dom.org/release/x3dom.js"></script>
   <style>
-    html, body { height: 100%; margin: 0; }
-    body { display: grid; grid-template-columns: 320px 1fr; grid-template-rows: auto 1fr; font: 14px/1.4 system-ui; }
-    header { grid-column: 1 / -1; padding: 8px 12px; border-bottom: 1px solid #eee; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
-    header nav a { color: #1976d2; text-decoration: none; font-weight: 600; }
-    header nav a:hover { text-decoration: underline; }
-    aside { padding: 12px; border-right: 1px solid #eee; display: grid; gap: 8px; align-content: start; }
-    main { position: relative; }
-    x3d { width: 100%; height: calc(100vh - 48px); }
-    label { display: flex; justify-content: space-between; gap: 8px; }
-    input[type="number"] { width: 7em; }
-    .row { display: flex; gap: 8px; align-items: center; }
-    .note { font-size: 12px; color: #555; }
-    .btn { padding: 6px 10px; border: 1px solid #444; background: #f0f0f0; cursor: pointer; }
-    .file-label { flex-direction: column; align-items: flex-start; gap: 4px; font-weight: 600; }
-    .file-label input { width: 100%; }
+    :root {
+      color-scheme: light;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+      background: var(--room-ui-bg);
+      color: var(--room-ui-text);
+      display: grid;
+      grid-template-rows: auto 1fr;
+      min-height: 100vh;
+    }
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 14px 20px;
+      gap: 16px;
+      border-bottom: 1px solid var(--room-ui-border);
+      background: var(--room-ui-surface);
+      backdrop-filter: blur(6px);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+    header .subtitle {
+      font-size: 13px;
+      color: var(--room-ui-muted-strong);
+      margin-top: 2px;
+    }
+    nav {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .nav-link {
+      color: var(--room-ui-link);
+      text-decoration: none;
+      font-weight: 600;
+      padding: 6px 10px;
+      border-radius: 6px;
+      transition: background 120ms ease, color 120ms ease;
+    }
+    .nav-link:hover {
+      background: rgba(37, 99, 235, 0.12);
+    }
+    .nav-link.active {
+      background: rgba(37, 99, 235, 0.18);
+    }
+    main {
+      display: grid;
+      grid-template-columns: minmax(280px, 340px) 1fr;
+      gap: 20px;
+      padding: 24px;
+      min-height: 0;
+    }
+    aside {
+      display: grid;
+      gap: 16px;
+      align-content: start;
+    }
+    .panel {
+      background: var(--room-ui-surface);
+      border-radius: 14px;
+      padding: 18px;
+      border: 1px solid var(--room-ui-border-soft);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+      display: grid;
+      gap: 12px;
+    }
+    .panel hr {
+      border: none;
+      border-top: 1px solid var(--room-ui-border-soft);
+      margin: 12px -18px;
+    }
+    label {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--room-ui-muted-strong);
+    }
+    input[type="number"] {
+      width: 7em;
+      font: inherit;
+      padding: 6px 8px;
+      border-radius: 6px;
+      border: 1px solid var(--room-ui-border);
+      background: rgba(255, 255, 255, 0.92);
+      color: inherit;
+    }
+    .file-label {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 6px;
+      font-weight: 600;
+    }
+    .file-label input {
+      width: 100%;
+      font: inherit;
+      padding: 6px 8px;
+      border-radius: 6px;
+      border: 1px solid var(--room-ui-border);
+      background: rgba(255, 255, 255, 0.92);
+      color: inherit;
+    }
+    .row {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+    .note {
+      font-size: 13px;
+      color: var(--room-ui-muted);
+    }
+    .btn {
+      appearance: none;
+      font: inherit;
+      padding: 8px 12px;
+      border-radius: 8px;
+      border: 1px solid var(--room-ui-button-border);
+      background: linear-gradient(180deg, var(--room-ui-button-bg-top), var(--room-ui-button-bg-bottom));
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+    .btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 16px var(--room-ui-shadow);
+    }
+    .viewport {
+      background: var(--room-ui-viewport-bg);
+      border-radius: 18px;
+      border: 1px solid var(--room-ui-border-soft);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
+      overflow: hidden;
+      display: flex;
+      min-height: 0;
+    }
+    x3d {
+      width: 100%;
+      height: 100%;
+    }
   </style>
 </head>
 <body>
   <header>
-    <div class="title"><strong>Interactive 3D Room</strong> — inputs on the left. Y-up (X3D), ground plane is X–Z. Height is fixed to 8&nbsp;ft (2.4384&nbsp;m).</div>
+    <div>
+      <strong>Interactive 3D Room — Orbit Viewer</strong>
+      <div class="subtitle">Review walls, doors, and items from the exported survey before committing to the layout.</div>
+    </div>
     <nav>
-      <a href="../room_survey_min/room_survey_min_v1.html">Open 2D Layout</a>
-      <a href="interactive_3d_room_fps_demo.html">First-Person Demo</a>
+      <a class="nav-link" href="../index.html">Home</a>
+      <a class="nav-link" href="../room_survey_min/room_survey_min_v1.html">2D Survey</a>
+      <a class="nav-link active" href="interactive_3d_room_v1.html">Orbit Viewer</a>
+      <a class="nav-link" href="interactive_3d_room_fps_demo.html">First-Person Demo</a>
     </nav>
   </header>
-  <aside>
-    <div class="row"><strong>Units:</strong> millimeters for inputs; converted to meters in 3D.</div>
-    <label>Room Width (X, mm) <input id="Wmm" type="number" min="1000" value="6000" step="100"></label>
-    <label>Room Length (Y, mm) <input id="Lmm" type="number" min="1000" value="8000" step="100"></label>
-    <div class="note">Height is fixed to 8 ft = 2438.4 mm.</div>
-    <hr>
-    <label>Triangle X (mm) <input id="Txmm" type="number" min="0" value="3000" step="50"></label>
-    <label>Triangle Y (mm) <input id="Tymm" type="number" min="0" value="3000" step="50"></label>
-    <div class="row">
-      <button class="btn" id="apply">Apply</button>
-      <button class="btn" id="home">Home View</button>
-    </div>
-    <div class="note">Triangle is a flat marker on the floor. (X, Y) here maps to (X, Z) in the 3D scene.</div>
-    <hr>
-    <label class="file-label">Import 2D JSON <input id="import2d" type="file" accept="application/json"></label>
-    <div class="note">Load a layout exported from the 2D survey. Dimensions and items are populated automatically.</div>
-  </aside>
   <main>
-    <x3d id="viewer" showStat="false" showLog="false">
-      <Scene>
-        <Background skyColor="0.98 0.98 0.98"></Background>
-        <NavigationInfo type='"EXAMINE","ANY"' headlight="true"></NavigationInfo>
-        <Viewpoint id="vp" description="Home" position="4 2 4" orientation="0 1 0 0"></Viewpoint>
+    <aside>
+      <div class="panel">
+        <div class="row"><strong>Units:</strong> millimeters for inputs; converted to meters in 3D.</div>
+        <label>Room Width (X, mm) <input id="Wmm" type="number" min="1000" value="6000" step="100"></label>
+        <label>Room Length (Y, mm) <input id="Lmm" type="number" min="1000" value="8000" step="100"></label>
+        <div class="note">Height is fixed to 8 ft = 2438.4 mm.</div>
+        <hr>
+        <label>Triangle X (mm) <input id="Txmm" type="number" min="0" value="3000" step="50"></label>
+        <label>Triangle Y (mm) <input id="Tymm" type="number" min="0" value="3000" step="50"></label>
+        <div class="row">
+          <button class="btn" id="apply">Apply</button>
+          <button class="btn" id="home">Home View</button>
+        </div>
+        <div class="note">Triangle is a flat marker on the floor. (X, Y) maps to (X, Z) in the 3D scene.</div>
+        <hr>
+        <label class="file-label">Import 2D JSON <input id="import2d" type="file" accept="application/json"></label>
+        <div class="note">Load a layout exported from the 2D survey. Dimensions and items are populated automatically.</div>
+      </div>
+    </aside>
+    <section class="viewport">
+      <x3d id="viewer" showStat="false" showLog="false">
+        <Scene>
+          <Background skyColor="0.98 0.98 0.98"></Background>
+          <NavigationInfo type='"EXAMINE","ANY"' headlight="true"></NavigationInfo>
+          <Viewpoint id="vp" description="Home" position="4 2 4" orientation="0 1 0 0"></Viewpoint>
 
-        <!-- Room wireframe -->
-        <Transform id="roomTf">
-          <Shape>
-            <Appearance><Material emissiveColor="0.1 0.1 0.1"></Material></Appearance>
-            <IndexedLineSet id="roomEdges" coordIndex="">
-              <Coordinate id="roomCoords" point=""></Coordinate>
-            </IndexedLineSet>
-          </Shape>
-        </Transform>
+          <!-- Room wireframe -->
+          <Transform id="roomTf">
+            <Shape>
+              <Appearance><Material emissiveColor="0.1 0.1 0.1"></Material></Appearance>
+              <IndexedLineSet id="roomEdges" coordIndex="">
+                <Coordinate id="roomCoords" point=""></Coordinate>
+              </IndexedLineSet>
+            </Shape>
+          </Transform>
 
-        <!-- Floor grid (1m spacing, auto-extended around room size) -->
-        <Transform id="gridTf">
-          <Shape>
-            <Appearance><Material emissiveColor="0.85 0.85 0.85"></Material></Appearance>
-            <IndexedLineSet id="gridLines" coordIndex=""></IndexedLineSet>
-          </Shape>
-        </Transform>
+          <!-- Floor grid (1m spacing, auto-extended around room size) -->
+          <Transform id="gridTf">
+            <Shape>
+              <Appearance><Material emissiveColor="0.85 0.85 0.85"></Material></Appearance>
+              <IndexedLineSet id="gridLines" coordIndex=""></IndexedLineSet>
+            </Shape>
+          </Transform>
 
-        <!-- Triangle marker (flat on floor Y=0) -->
-        <Transform id="triTf" translation="0 0 0">
-          <Shape>
-            <Appearance><Material diffuseColor="0.2 0.5 0.95" transparency="0.2"></Material></Appearance>
-            <IndexedFaceSet coordIndex="0 1 2 -1">
-              <Coordinate id="triCoords" point="-0.2 0 0  0.2 0 0  0 0 0.3"></Coordinate>
-            </IndexedFaceSet>
-          </Shape>
-        </Transform>
+          <!-- Triangle marker (flat on floor Y=0) -->
+          <Transform id="triTf" translation="0 0 0">
+            <Shape>
+              <Appearance><Material diffuseColor="0.2 0.5 0.95" transparency="0.2"></Material></Appearance>
+              <IndexedFaceSet coordIndex="0 1 2 -1">
+                <Coordinate id="triCoords" point="-0.2 0 0  0.2 0 0  0 0 0.3"></Coordinate>
+              </IndexedFaceSet>
+            </Shape>
+          </Transform>
 
-        <!-- Extruded items (populated from 2D layout) -->
-        <Transform id="wallsRoot"></Transform>
-        <Transform id="doorsRoot"></Transform>
-        <Transform id="itemsRoot"></Transform>
-      </Scene>
-    </x3d>
+          <!-- Extruded items (populated from 2D layout) -->
+          <Transform id="wallsRoot"></Transform>
+          <Transform id="doorsRoot"></Transform>
+          <Transform id="itemsRoot"></Transform>
+        </Scene>
+      </x3d>
+    </section>
   </main>
 
-<script>
+  <script>
+
 const mm2m = v => v / 1000.0;
 const FT8_MM = 2438.4; // 8 feet
 const Hm = mm2m(FT8_MM);
@@ -125,6 +269,22 @@ const FLOOR_ITEM_META = {
   table: { wmm: 1800, lmm: 900, color: '0.23 0.33 0.68', height: 0.9 },
   pump: { wmm: 1200, lmm: 600, color: '0.93 0.44 0.13', height: 0.6 }
 };
+
+const DEFAULT_ROOM_PRESET = () => ({
+  room: { W: 6000, L: 8000 },
+  floor_items: [
+    { type: 'microscope', x: 2200, y: 5200, rotation: 0 },
+    { type: 'table', x: 3800, y: 5200, rotation: 0 },
+    { type: 'pump', x: 4200, y: 3400, rotation: 0 },
+    { type: 'floorBox', x: 3000, y: 3600, rotation: 0 }
+  ],
+  wall_items: [
+    { type: 'socket', wall: 'base:1', s: 1500, h: 300 },
+    { type: 'socket', wall: 'base:3', s: 4500, h: 300 }
+  ],
+  custom_walls: [],
+  doors: []
+});
 
 const WALL_COLOR = '0.84 0.80 0.76';
 const CUSTOM_WALL_COLOR = '0.65 0.50 0.42';
@@ -462,6 +622,21 @@ function apply() {
   renderLayout3d();
 }
 
+
+function applyDefaultPreset() {
+  const preset = DEFAULT_ROOM_PRESET();
+  layout.room.Wmm = preset.room.W;
+  layout.room.Lmm = preset.room.L;
+  Wmm.value = layout.room.Wmm;
+  Lmm.value = layout.room.Lmm;
+  layout.floor_items = (preset.floor_items || []).map(normalizeFloorItem);
+  layout.wall_items = (preset.wall_items || []).map(normalizeWallItem);
+  layout.custom_walls = (preset.custom_walls || []).map(normalizeCustomWall);
+  layout.doors = (preset.doors || []).map(normalizeDoor);
+  ensureLayoutIds();
+  apply();
+}
+
 applyBtn.addEventListener('click', apply);
 
 homeBtn.addEventListener('click', () => {
@@ -485,8 +660,7 @@ importInput.addEventListener('change', evt => {
   reader.readAsText(file);
 });
 
-ensureLayoutIds();
-apply();
-</script>
+applyDefaultPreset();
+  </script>
 </body>
 </html>

--- a/dev/room_survey_min/room_survey_min_v1.html
+++ b/dev/room_survey_min/room_survey_min_v1.html
@@ -1,22 +1,164 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <!-- Prototype version 1 (baseline implementation used as source for future iterations) -->
   <meta charset="utf-8" />
   <title>Room Survey (SVG Drag + Snap) — v1 Baseline</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../shared/styles/glass_light_theme.css" />
   <style>
-    body { font: 14px/1.4 system-ui; margin: 16px; }
-    .row { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; margin-bottom: 8px; }
-    label { display: inline-flex; align-items: center; gap: 6px; }
-    input[type="number"] { width: 7em; }
-    #stage { border: 1px solid #ccc; background: #fafafa; }
-    .btn { padding: 6px 10px; border: 1px solid #444; background: #f0f0f0; cursor: pointer; }
-    .legend { margin-top: 8px; }
-    .dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; margin-right: 6px; vertical-align: middle; }
-    .hud { font: 12px/1.2 system-ui; color: #333; }
-    .toggle { display: inline-flex; align-items: center; gap: 6px; }
-    .note { font-size: 12px; color: #555; max-width: 420px; }
-    .wall-choice { min-width: 220px; }
+    :root {
+      color-scheme: light;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+      background: var(--room-ui-bg);
+      color: var(--room-ui-text);
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: auto 1fr;
+    }
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 14px 20px;
+      gap: 16px;
+      border-bottom: 1px solid var(--room-ui-border);
+      background: var(--room-ui-surface);
+      backdrop-filter: blur(6px);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+    header .subtitle {
+      font-size: 13px;
+      color: var(--room-ui-muted-strong);
+      margin-top: 2px;
+    }
+    nav {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .nav-link {
+      text-decoration: none;
+      font-weight: 600;
+      color: var(--room-ui-link);
+      padding: 6px 10px;
+      border-radius: 6px;
+      transition: background 120ms ease, color 120ms ease;
+    }
+    .nav-link:hover {
+      background: rgba(37, 99, 235, 0.12);
+    }
+    .nav-link.active {
+      background: rgba(37, 99, 235, 0.18);
+    }
+    main {
+      display: grid;
+      grid-template-columns: minmax(280px, 360px) 1fr;
+      gap: 20px;
+      padding: 24px;
+      align-items: start;
+    }
+    aside {
+      display: grid;
+      gap: 20px;
+    }
+    .panel {
+      background: var(--room-ui-surface);
+      border-radius: 14px;
+      padding: 18px;
+      border: 1px solid var(--room-ui-border-soft);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+      display: grid;
+      gap: 12px;
+    }
+    .stage-panel {
+      padding: 0;
+      overflow: hidden;
+    }
+    .stage-panel-inner {
+      padding: 18px;
+      display: grid;
+      gap: 12px;
+    }
+    .row {
+      display: flex;
+      gap: 14px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+    label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--room-ui-muted-strong);
+    }
+    label input,
+    label select {
+      font: inherit;
+      padding: 6px 8px;
+      border-radius: 6px;
+      border: 1px solid var(--room-ui-border);
+      background: rgba(255, 255, 255, 0.92);
+      min-width: 7em;
+      color: inherit;
+    }
+    input[type="number"] {
+      width: 7em;
+    }
+    .btn {
+      appearance: none;
+      font: inherit;
+      padding: 8px 12px;
+      border-radius: 8px;
+      border: 1px solid var(--room-ui-button-border);
+      background: linear-gradient(180deg, var(--room-ui-button-bg-top), var(--room-ui-button-bg-bottom));
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+    .btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 16px var(--room-ui-shadow);
+    }
+    .legend {
+      display: grid;
+      gap: 6px;
+      font-size: 13px;
+      color: var(--room-ui-muted-strong);
+    }
+    .dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      display: inline-block;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
+    .hud {
+      font-size: 13px;
+      color: var(--room-ui-muted-strong);
+    }
+    .toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .note {
+      font-size: 13px;
+      color: var(--room-ui-muted);
+    }
+    .wall-choice {
+      min-width: 220px;
+    }
     .handle { fill: #fff; stroke: #333; stroke-width: 1.5; cursor: pointer; }
     .custom-wall-line { cursor: move; }
     #roomRect.floor-selected { stroke: #1976d2; stroke-width: 3; }
@@ -28,100 +170,133 @@
     body[data-mode="basic"] .custom-only { display: none !important; }
     body[data-mode="custom"] .basic-only { display: none !important; }
     body[data-mode="basic"] .wall-choice { display: none !important; }
+    #stage {
+      width: 100%;
+      height: auto;
+      max-width: 900px;
+      border: 1px solid var(--room-ui-border);
+      background: rgba(255, 255, 255, 0.8);
+      display: block;
+    }
+    .workspace {
+      display: grid;
+      gap: 20px;
+    }
+    .export-panel {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
   </style>
 </head>
 <body>
-<h1>Room Survey (Top-Down)</h1>
+  <header>
+    <div>
+      <strong>Room Survey (Top-Down)</strong>
+      <div class="subtitle">Plan microscope placement, adjust walls, and export layouts for 3D review.</div>
+    </div>
+    <nav>
+      <a class="nav-link" href="../index.html">Home</a>
+      <a class="nav-link active" href="room_survey_min_v1.html">2D Survey</a>
+      <a class="nav-link" href="../interactive_3d_room/interactive_3d_room_v1.html">Orbit Viewer</a>
+      <a class="nav-link" href="../interactive_3d_room/interactive_3d_room_fps_demo.html">First-Person Demo</a>
+    </nav>
+  </header>
+  <main>
+    <aside>
+      <div class="panel">
+        <div class="row" id="primaryControls">
+          <label class="toggle">Room type
+            <select id="roomType">
+              <option value="basic">Basic (Rectangular)</option>
+              <option value="custom">Custom Layout</option>
+            </select>
+          </label>
+          <label class="dim">Width W (mm) <input id="W" type="number" value="6000" min="1000"></label>
+          <label class="dim">Length L (mm) <input id="L" type="number" value="8000" min="1000"></label>
+          <label class="custom-only">Snap (mm) <input id="snap" type="number" value="100" min="10" step="10" title="Grid snap step in millimeters"></label>
+          <label class="toggle custom-only"><input id="imperial" type="checkbox"> Show imperial (in) &amp; use 150&nbsp;mm snap</label>
+          <button class="btn" id="apply">Apply</button>
+        </div>
+        <div class="row basic-only" id="basicAddRow">
+          <label>
+            Add item:
+            <select id="basicAddType">
+              <option value="microscope">Microscope</option>
+              <option value="table">Table</option>
+              <option value="pump">Vacuum Pump</option>
+            </select>
+          </label>
+          <button class="btn" id="basicAdd">Add</button>
+        </div>
+        <div class="row custom-only" id="customAddRow">
+          <label>
+            Add:
+            <select id="addType">
+              <option value="floorBox">Floor Box</option>
+              <option value="microscope">Microscope</option>
+              <option value="table">Table</option>
+              <option value="pump">Vacuum Pump</option>
+              <option value="socket">Wall Socket</option>
+            </select>
+          </label>
+          <label class="wall-choice">
+            Wall for socket:
+            <select id="wallSel"></select>
+          </label>
+          <button class="btn" id="add">Add</button>
+        </div>
+        <div class="row custom-only" id="structureRow">
+          <button class="btn" id="addWall">Draw Wall</button>
+          <button class="btn" id="addDoor">Add Door to Selected Wall</button>
+          <span class="note">Select a wall or floor to attach items. Drag wall end dots to reshape custom walls.</span>
+        </div>
+        <div class="note">Switch to the custom layout to draw new walls, add doors, and place sockets on specific runs.</div>
+      </div>
+      <div class="panel legend">
+        <div><span class="dot" style="background:#1e88e5"></span>Floor Box</div>
+        <div><span class="dot" style="background:#f9a825"></span>Socket</div>
+        <div><span class="dot" style="background:#8e24aa"></span>Microscope</div>
+        <div><span class="dot" style="background:#3949ab"></span>Table</div>
+        <div><span class="dot" style="background:#ef6c00"></span>Vacuum Pump</div>
+      </div>
+    </aside>
+    <section class="workspace">
+      <div class="panel stage-panel">
+        <div class="stage-panel-inner">
+          <svg id="stage" width="900" height="640" viewBox="0 0 900 640">
+            <!-- Room rectangle (scaled to fit) -->
+            <g id="roomGroup">
+              <rect id="roomRect" x="50" y="50" width="700" height="500" fill="none" stroke="#333" stroke-width="2"/>
+              <!-- Origin marker (rear-left corner) -->
+              <circle id="origin" cx="50" cy="550" r="5" fill="#d33"></circle>
+              <text x="60" y="545" font-size="12">Origin (0,0)</text>
+              <!-- grid group -->
+              <g id="grid"></g>
+            </g>
 
-<div class="row" id="primaryControls">
-  <label class="toggle">Room type
-    <select id="roomType">
-      <option value="basic">Basic (Rectangular)</option>
-      <option value="custom">Custom Layout</option>
-    </select>
-  </label>
-  <label class="dim">Width W (mm) <input id="W" type="number" value="6000" min="1000"></label>
-  <label class="dim">Length L (mm) <input id="L" type="number" value="8000" min="1000"></label>
-  <label class="custom-only">Snap (mm) <input id="snap" type="number" value="100" min="10" step="10" title="Grid snap step in millimeters"></label>
-  <label class="toggle custom-only"><input id="imperial" type="checkbox"> Show imperial (in) & use 150&nbsp;mm snap</label>
-  <button class="btn" id="apply">Apply</button>
-</div>
+            <!-- Draggable items -->
+            <g id="baseWallsOverlay"></g>
+            <g id="wallLabels"></g>
+            <g id="selectionOverlay"></g>
+            <g id="customWalls"></g>
+            <g id="doorsLayer"></g>
+            <g id="floorItems"></g>
+            <g id="wallItems"></g>
+          </svg>
+        </div>
+      </div>
+      <div class="panel export-panel" id="exportRow">
+        <button class="btn" id="export">Export JSON</button>
+        <span class="hud" id="hud"></span>
+      </div>
+    </section>
+  </main>
 
-<div class="row basic-only" id="basicAddRow">
-  <label>
-    Add item:
-    <select id="basicAddType">
-      <option value="microscope">Microscope</option>
-      <option value="table">Table</option>
-      <option value="pump">Vacuum Pump</option>
-    </select>
-  </label>
-  <button class="btn" id="basicAdd">Add</button>
-</div>
+  <script>
 
-<div class="row custom-only" id="customAddRow">
-  <label>
-    Add:
-    <select id="addType">
-      <option value="floorBox">Floor Box</option>
-      <option value="microscope">Microscope</option>
-      <option value="table">Table</option>
-      <option value="pump">Vacuum Pump</option>
-      <option value="socket">Wall Socket</option>
-    </select>
-  </label>
-  <label class="wall-choice">
-    Wall for socket:
-    <select id="wallSel"></select>
-  </label>
-  <button class="btn" id="add">Add</button>
-</div>
-
-<div class="row custom-only" id="structureRow">
-  <button class="btn" id="addWall">Draw Wall</button>
-  <button class="btn" id="addDoor">Add Door to Selected Wall</button>
-  <span class="note">Select a wall or floor to attach items. Drag wall end dots to reshape custom walls.</span>
-</div>
-
-<svg id="stage" width="900" height="640" viewBox="0 0 900 640">
-  <!-- Room rectangle (scaled to fit) -->
-  <g id="roomGroup">
-    <rect id="roomRect" x="50" y="50" width="700" height="500" fill="none" stroke="#333" stroke-width="2"/>
-    <!-- Origin marker (rear-left corner) -->
-    <circle id="origin" cx="50" cy="550" r="5" fill="#d33"></circle>
-    <text x="60" y="545" font-size="12">Origin (0,0)</text>
-    <!-- grid group -->
-    <g id="grid"></g>
-  </g>
-
-  <!-- Draggable items -->
-  <g id="baseWallsOverlay"></g>
-  <g id="wallLabels"></g>
-  <g id="selectionOverlay"></g>
-  <g id="customWalls"></g>
-  <g id="doorsLayer"></g>
-  <g id="floorItems"></g>
-  <g id="wallItems"></g>
-</svg>
-
-<div class="row" id="exportRow">
-  <button class="btn" id="export">Export JSON</button>
-  <span class="hud" id="hud"></span>
-</div>
-
-<div class="legend">
-  <span class="dot" style="background:#1e88e5"></span>Floor Box
-  &nbsp;&nbsp;
-  <span class="dot" style="background:#f9a825"></span>Socket
-  &nbsp;&nbsp;
-  <span class="dot" style="background:#8e24aa"></span>Microscope
-  &nbsp;&nbsp;
-  <span class="dot" style="background:#3949ab"></span>Table
-  &nbsp;&nbsp;
-  <span class="dot" style="background:#ef6c00"></span>Vacuum Pump
-</div>
-
-<script>
 const bodyEl = document.body;
 const svg = document.getElementById('stage');
 const roomTypeSel = document.getElementById('roomType');
@@ -158,6 +333,20 @@ const FLOOR_ITEM_DEFS = {
   pump: { label: 'Vacuum Pump', w: 1200, l: 600, fill: '#ef6c00', stroke: '#e65100' }
 };
 
+const DEFAULT_ROOM_PRESET = () => ({
+  room: { W: 6000, L: 8000 },
+  floor_items: [
+    { type: 'microscope', x: 2200, y: 5200, rotation: 0 },
+    { type: 'table', x: 3800, y: 5200, rotation: 0 },
+    { type: 'pump', x: 4200, y: 3400, rotation: 0 },
+    { type: 'floorBox', x: 3000, y: 3600, rotation: 0 }
+  ],
+  wall_items: [
+    { type: 'socket', wall: 'base:1', s: 1500, h: 300 },
+    { type: 'socket', wall: 'base:3', s: 4500, h: 300 }
+  ]
+});
+
 const BASE_WALL_THICKNESS = 200;
 const DOOR_DEFAULT_WIDTH = 900;
 const DOOR_DEFAULT_THICKNESS = 80;
@@ -182,6 +371,43 @@ const state = {
 let hudTransient = null;
 let drawWallState = null;
 function showHud(message) { hudTransient = message; }
+
+function isEditingFormControl(el) {
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  const tag = el.tagName;
+  if (!tag) return false;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+function applyDefaultPreset() {
+  const preset = DEFAULT_ROOM_PRESET();
+  state.Wmm = preset.room.W;
+  state.Lmm = preset.room.L;
+  state.floorItems = preset.floor_items.map(item => {
+    const def = FLOOR_ITEM_DEFS[item.type] || FLOOR_ITEM_DEFS.floorBox;
+    return {
+      id: genId('floor'),
+      type: item.type,
+      x: snapValue(item.x),
+      y: snapValue(item.y),
+      w: item.w || def.w,
+      l: item.l || def.l,
+      rotation: item.rotation || 0
+    };
+  });
+  state.wallItems = preset.wall_items.map(item => ({
+    id: genId(item.type === 'socket' ? 'socket' : 'wallItem'),
+    ...item
+  }));
+  state.customWalls = [];
+  state.doors = [];
+  state.selectedSurface = { type: 'floor' };
+  Winput.value = state.Wmm;
+  Linput.value = state.Lmm;
+  snapInput.value = state.snap;
+}
+
 
 function mmToIn(mm) { return mm / 25.4; }
 function fmtLen(mm) {
@@ -948,11 +1174,21 @@ function deleteSelectedItem() {
 
 document.addEventListener('keydown', evt => {
   if (evt.key !== 'Delete' && evt.key !== 'Backspace') return;
+  if (isEditingFormControl(document.activeElement)) return;
   const message = deleteSelectedItem();
   if (message) {
     evt.preventDefault();
     showHud(message);
     render();
+  }
+});
+
+document.addEventListener('focusin', evt => {
+  const target = evt.target;
+  if (!(target instanceof HTMLElement)) return;
+  if (svg.contains(target)) return;
+  if (state.selectedSurface?.type && state.selectedSurface.type !== 'floor') {
+    setSelectedSurface({ type: 'floor' });
   }
 });
 
@@ -1140,9 +1376,10 @@ roomTypeSel.addEventListener('change', () => {
 });
 
 // initialize
+applyDefaultPreset();
 setMode('basic');
 recomputeScale();
 render();
-</script>
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a themed landing page and consistent navigation links across the survey and 3D demos
- preload the microscope room layout in each experience and guard delete shortcuts while editing form fields
- align the first-person viewer with the default preset and clear selections when importing or resetting layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def7db3e50832983875e8ba6090caf