### PR TITLE
Add layout persistence, dark theme, and local server for orbit viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,11 @@
 - Added grid-snapped wall and door editing, wall edge labels, and delete-key support to `room_survey_min_v1.html` for a clearer custom-layout workflow.
 - Captured the translucent "glass light" UI treatment as `dev/shared/styles/glass_light_theme.css` and wired it into the first-person 3D demo, along with control tips.
 - Hardened `interactive_3d_room_fps_demo.html` for broader browser compatibility and added Ctrl-drag orbiting while outside walk mode.
+
+## 2025-10-02
+- feat: complete step [p1] Audit `interactive_3d_room_v1.html` – corrected navigation mode and viewport styling to keep the scene from free-falling on load.
+- feat: complete step [p1] Restore orbit viewer buttons – rewired Apply/Home actions to refresh the scene, reset the camera, and surface status feedback.
+- feat: complete step [p1] Add explicit Save and Load controls – introduced UI buttons, status messaging, and snapshot helpers to persist layouts.
+- feat: complete step [p1] Stand up a minimal Python HTTP server – added a threaded standard-library server with JSON persistence endpoints and tests.
+- feat: complete step [p2] Apply shared glass-light dark theme tokens – overhauled the orbit viewer styling and background to match the suite’s dark treatment.
+- feat: complete step [p2] Persist layout data client-side – synced localStorage restores with imports and automatic saves when the viewer loads or updates.

--- a/PROBLEMS.md
+++ b/PROBLEMS.md
@@ -1,0 +1,3 @@
+# Problem → Solution Log
+- 2025-10-02: `pytest -q --maxfail=1 --cov=.` failed because `pytest-cov` is not installed in the environment. Reran the suite without the coverage flag once tests were configured.
+- 2025-10-02: `pip install flask` was blocked by the environment proxy (403). Replaced the Flask dependency with a standard-library HTTP server implementation instead.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,10 @@
 # TODO
 
-- Catalog reusable "glass light" theme tokens for other room survey prototypes and expand the shared theme library as new looks emerge.
-- Evaluate additional camera input affordances (e.g., touch gestures and keyboard shortcuts) for the 3D first-person demo after the next round of feedback.
+✅ [p1] Audit `interactive_3d_room_v1.html` to stop the scene from "falling" on load by correcting any viewport sizing or camera animation issues.
+✅ [p1] Restore orbit viewer buttons (Apply/Home) so they reliably update the scene and camera without console errors.
+✅ [p1] Add explicit Save and Load controls that persist the latest room layout export for reuse after navigating away.
+✅ [p1] Stand up a minimal Python HTTP server (Flask alternative) to serve the prototype and expose JSON save/load endpoints backed by a local file store.
+✅ [p2] Apply the shared glass-light dark theme tokens to the orbit viewer layout so the styling matches the rest of the prototype suite.
+✅ [p2] Persist imported or edited layout data client-side so it reloads automatically when the viewer opens.
+🔲 [p3] Catalog reusable "glass light" theme tokens for other room survey prototypes and expand the shared theme library as new looks emerge.
+🔲 [p3] Evaluate additional camera input affordances (e.g., touch gestures and keyboard shortcuts) for the 3D first-person demo after the next round of feedback.

--- a/dev/__init__.py
+++ b/dev/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for the room survey development prototypes."""

--- a/dev/interactive_3d_room/interactive_3d_room_v1.html
+++ b/dev/interactive_3d_room/interactive_3d_room_v1.html
@@ -7,10 +7,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="https://www.x3dom.org/release/x3dom.css">
   <link rel="stylesheet" href="../shared/styles/glass_light_theme.css" />
+  <link rel="stylesheet" href="../shared/styles/glass_dark_theme.css" />
   <script src="https://www.x3dom.org/release/x3dom.js"></script>
   <style>
     :root {
-      color-scheme: light;
+      color-scheme: dark;
     }
     * {
       box-sizing: border-box;
@@ -23,6 +24,18 @@
       display: grid;
       grid-template-rows: auto 1fr;
       min-height: 100vh;
+      position: relative;
+      overflow-x: hidden;
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(circle at 15% 20%, rgba(96, 165, 250, 0.18), transparent 45%),
+                  radial-gradient(circle at 85% 10%, rgba(99, 102, 241, 0.22), transparent 52%);
+      opacity: 0.75;
+      pointer-events: none;
+      z-index: -2;
     }
     header {
       display: flex;
@@ -67,6 +80,11 @@
       gap: 20px;
       padding: 24px;
       min-height: 0;
+    }
+    @media (max-width: 960px) {
+      main {
+        grid-template-columns: 1fr;
+      }
     }
     aside {
       display: grid;
@@ -143,6 +161,17 @@
       transform: translateY(-1px);
       box-shadow: 0 6px 16px var(--room-ui-shadow);
     }
+    .btn.secondary {
+      border-color: rgba(148, 163, 184, 0.25);
+      background: rgba(30, 41, 59, 0.78);
+      color: var(--room-ui-link);
+    }
+    .btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      box-shadow: none;
+      transform: none;
+    }
     .viewport {
       background: var(--room-ui-viewport-bg);
       border-radius: 18px;
@@ -155,10 +184,26 @@
     x3d {
       width: 100%;
       height: 100%;
+      min-height: 520px;
+    }
+    .status-line {
+      font-size: 13px;
+      color: var(--room-ui-muted);
+      min-height: 18px;
+      transition: color 160ms ease;
+    }
+    .status-line[data-tone="success"] {
+      color: #34d399;
+    }
+    .status-line[data-tone="warn"] {
+      color: #facc15;
+    }
+    .status-line[data-tone="error"] {
+      color: #f87171;
     }
   </style>
 </head>
-<body>
+<body data-room-theme="glass-dark">
   <header>
     <div>
       <strong>Interactive 3D Room — Orbit Viewer</strong>
@@ -189,13 +234,18 @@
         <hr>
         <label class="file-label">Import 2D JSON <input id="import2d" type="file" accept="application/json"></label>
         <div class="note">Load a layout exported from the 2D survey. Dimensions and items are populated automatically.</div>
+        <div class="row">
+          <button class="btn secondary" id="saveLayout">Save Layout</button>
+          <button class="btn secondary" id="loadLayout">Load Saved</button>
+        </div>
+        <div class="status-line" id="statusLine" role="status" aria-live="polite"></div>
       </div>
     </aside>
     <section class="viewport">
       <x3d id="viewer" showStat="false" showLog="false">
         <Scene>
-          <Background skyColor="0.98 0.98 0.98"></Background>
-          <NavigationInfo type='"EXAMINE","ANY"' headlight="true"></NavigationInfo>
+          <Background skyColor="0.06 0.08 0.14"></Background>
+          <NavigationInfo type='"EXAMINE" "ANY"' headlight="true"></NavigationInfo>
           <Viewpoint id="vp" description="Home" position="4 2 4" orientation="0 1 0 0"></Viewpoint>
 
           <!-- Room wireframe -->
@@ -248,6 +298,9 @@ const Tymm = document.getElementById('Tymm');
 const applyBtn = document.getElementById('apply');
 const homeBtn = document.getElementById('home');
 const importInput = document.getElementById('import2d');
+const saveBtn = document.getElementById('saveLayout');
+const loadBtn = document.getElementById('loadLayout');
+const statusLine = document.getElementById('statusLine');
 
 const vp = document.getElementById('vp');
 const roomCoords = document.getElementById('roomCoords');
@@ -258,10 +311,13 @@ const triCoords = document.getElementById('triCoords');
 const wallsRoot = document.getElementById('wallsRoot');
 const doorsRoot = document.getElementById('doorsRoot');
 const itemsRoot = document.getElementById('itemsRoot');
+const viewer = document.getElementById('viewer');
 
 const DEFAULT_WALL_THICKNESS_MM = 200;
 const DOOR_DEFAULT_THICKNESS_MM = 80;
 const DOOR_HEIGHT_M = 2.1;
+const LAYOUT_STORAGE_KEY = 'room-orbit-viewer.latest-layout';
+const STATUS_TIMEOUT_MS = 3200;
 
 const FLOOR_ITEM_META = {
   floorBox: { wmm: 600, lmm: 600, color: '0.12 0.53 0.90', height: 0.05 },
@@ -292,11 +348,13 @@ const DOOR_COLOR = '0.29 0.63 0.34';
 
 const layout = {
   room: { Wmm: Number(Wmm.value || 6000), Lmm: Number(Lmm.value || 8000) },
+  triangle: { x: Number(Txmm.value || 0), y: Number(Tymm.value || 0) },
   floor_items: [],
   wall_items: [],
   custom_walls: [],
   doors: []
 };
+let statusTimer = null;
 
 function toNumber(value, fallback = 0) {
   const v = Number(value);
@@ -305,6 +363,150 @@ function toNumber(value, fallback = 0) {
 
 function clearChildren(node) {
   while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+function showStatus(message, tone = 'info') {
+  if (!statusLine) return;
+  if (statusTimer) {
+    clearTimeout(statusTimer);
+    statusTimer = null;
+  }
+  if (!message) {
+    statusLine.textContent = '';
+    statusLine.removeAttribute('data-tone');
+    return;
+  }
+  statusLine.textContent = message;
+  statusLine.dataset.tone = tone;
+  statusTimer = setTimeout(() => {
+    statusLine.textContent = '';
+    statusLine.removeAttribute('data-tone');
+  }, STATUS_TIMEOUT_MS);
+}
+
+function persistLayoutLocal(data) {
+  try {
+    if (window.localStorage) {
+      window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(data));
+    }
+  } catch (err) {
+    console.warn('Failed to persist layout locally', err);
+  }
+}
+
+function loadLayoutLocal() {
+  try {
+    if (!window.localStorage) return null;
+    const raw = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (err) {
+    console.warn('Failed to load layout from local storage', err);
+    return null;
+  }
+}
+
+async function saveLayoutRemote(data) {
+  try {
+    const resp = await fetch('/api/layout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if (!resp.ok) throw new Error(await resp.text());
+    return true;
+  } catch (err) {
+    console.warn('Failed to save layout to server', err);
+    return false;
+  }
+}
+
+async function loadLayoutRemote() {
+  try {
+    const resp = await fetch('/api/layout', {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store'
+    });
+    if (!resp.ok) {
+      if (resp.status === 404) return null;
+      throw new Error(await resp.text());
+    }
+    const text = await resp.text();
+    if (!text) return null;
+    const payload = JSON.parse(text);
+    if (payload && typeof payload === 'object' && payload.layout !== undefined) {
+      return payload.layout;
+    }
+    if (payload && typeof payload === 'object') {
+      return payload;
+    }
+    return null;
+  } catch (err) {
+    console.warn('Failed to load layout from server', err);
+    return null;
+  }
+}
+
+function snapshotLayout() {
+  const triangle = layout.triangle || { x: 0, y: 0 };
+  return {
+    room: { W: toNumber(layout.room.Wmm, 6000), L: toNumber(layout.room.Lmm, 8000) },
+    triangle: {
+      x: toNumber(triangle.x, 0),
+      y: toNumber(triangle.y, 0)
+    },
+    floor_items: (layout.floor_items || []).map(item => {
+      const meta = FLOOR_ITEM_META[item.type] || FLOOR_ITEM_META.floorBox;
+      return {
+        id: item.id,
+        type: item.type,
+        x: toNumber(item.x, 0),
+        y: toNumber(item.y, 0),
+        w: toNumber(item.w, meta.wmm),
+        l: toNumber(item.l, meta.lmm),
+        rotation: toNumber(item.rotation, 0)
+      };
+    }),
+    wall_items: (layout.wall_items || []).map(item => ({
+      id: item.id,
+      type: item.type,
+      wall: item.wall,
+      s: toNumber(item.s, 0),
+      h: toNumber(item.h, 0)
+    })),
+    custom_walls: (layout.custom_walls || []).map(wall => ({
+      id: wall.id,
+      name: wall.name,
+      x1: toNumber(wall.x1, 0),
+      y1: toNumber(wall.y1, 0),
+      x2: toNumber(wall.x2, 0),
+      y2: toNumber(wall.y2, 0),
+      thickness: toNumber(wall.thickness, DEFAULT_WALL_THICKNESS_MM)
+    })),
+    doors: (layout.doors || []).map(door => ({
+      id: door.id,
+      wall: door.wall,
+      offset: toNumber(door.offset, 0),
+      width: toNumber(door.width, 900),
+      thickness: toNumber(door.thickness, DOOR_DEFAULT_THICKNESS_MM)
+    }))
+  };
+}
+
+async function restorePersistedLayout(options = {}) {
+  const { preferRemote = false } = options;
+  const order = preferRemote ? ['remote', 'local'] : ['local', 'remote'];
+  for (const source of order) {
+    if (source === 'local') {
+      const local = loadLayoutLocal();
+      if (local) return { data: local, source: 'local' };
+    } else {
+      const remote = await loadLayoutRemote();
+      if (remote) return { data: remote, source: 'server' };
+    }
+  }
+  return null;
 }
 
 function ensureLayoutIds() {
@@ -601,25 +803,45 @@ function ingestLayout(data) {
   if (Array.isArray(data.doors)) {
     layout.doors = data.doors.map(normalizeDoor);
   }
+  let triX = layout.triangle ? toNumber(layout.triangle.x, toNumber(Txmm.value, 0)) : toNumber(Txmm.value, 0);
+  let triY = layout.triangle ? toNumber(layout.triangle.y, toNumber(Tymm.value, 0)) : toNumber(Tymm.value, 0);
   if (data.triangle) {
-    if (data.triangle.x !== undefined) Txmm.value = toNumber(data.triangle.x, toNumber(Txmm.value, 0));
-    if (data.triangle.y !== undefined) Tymm.value = toNumber(data.triangle.y, toNumber(Tymm.value, 0));
+    if (data.triangle.x !== undefined) triX = toNumber(data.triangle.x, triX);
+    if (data.triangle.y !== undefined) triY = toNumber(data.triangle.y, triY);
   }
+  layout.triangle = { x: triX, y: triY };
+  Txmm.value = layout.triangle.x;
+  Tymm.value = layout.triangle.y;
   ensureLayoutIds();
 }
 
-function apply() {
+function apply(options = {}) {
+  const { fromUser = false, skipStatus = false, skipPersist = false } = options;
   layout.room.Wmm = toNumber(Wmm.value, layout.room.Wmm);
   layout.room.Lmm = toNumber(Lmm.value, layout.room.Lmm);
+  layout.triangle = {
+    x: toNumber(Txmm.value, layout.triangle ? layout.triangle.x : 0),
+    y: toNumber(Tymm.value, layout.triangle ? layout.triangle.y : 0)
+  };
   const Wm = mm2m(layout.room.Wmm);
   const Lm = mm2m(layout.room.Lmm);
-  const xm = mm2m(toNumber(Txmm.value, 0));
-  const zm = mm2m(toNumber(Tymm.value, 0));
+  const xm = mm2m(layout.triangle.x);
+  const zm = mm2m(layout.triangle.y);
   buildRoomEdges(Wm, Lm, Hm);
   buildGrid(Wm, Lm);
   updateTriangle(xm, zm);
   fitView(Wm, Lm, Hm);
+  if (viewer && viewer.runtime) {
+    if (typeof viewer.runtime.resetExamine === 'function') viewer.runtime.resetExamine();
+    if (typeof viewer.runtime.showAll === 'function') viewer.runtime.showAll();
+  }
   renderLayout3d();
+  if (!skipPersist) {
+    persistLayoutLocal(snapshotLayout());
+  }
+  if (fromUser && !skipStatus) {
+    showStatus('Layout updated.', 'success');
+  }
 }
 
 
@@ -633,14 +855,26 @@ function applyDefaultPreset() {
   layout.wall_items = (preset.wall_items || []).map(normalizeWallItem);
   layout.custom_walls = (preset.custom_walls || []).map(normalizeCustomWall);
   layout.doors = (preset.doors || []).map(normalizeDoor);
+  const presetTriangle = preset.triangle || { x: layout.room.Wmm / 2, y: layout.room.Lmm / 2 };
+  layout.triangle = {
+    x: toNumber(presetTriangle.x, layout.room.Wmm / 2),
+    y: toNumber(presetTriangle.y, layout.room.Lmm / 2)
+  };
+  Txmm.value = layout.triangle.x;
+  Tymm.value = layout.triangle.y;
   ensureLayoutIds();
-  apply();
+  apply({ skipStatus: true });
 }
 
-applyBtn.addEventListener('click', apply);
+applyBtn.addEventListener('click', () => apply({ fromUser: true }));
 
 homeBtn.addEventListener('click', () => {
   fitView(mm2m(layout.room.Wmm), mm2m(layout.room.Lmm), Hm);
+  if (viewer && viewer.runtime) {
+    if (typeof viewer.runtime.resetExamine === 'function') viewer.runtime.resetExamine();
+    if (typeof viewer.runtime.showAll === 'function') viewer.runtime.showAll();
+  }
+  showStatus('Camera reset to home view.', 'info');
 });
 
 importInput.addEventListener('change', evt => {
@@ -651,7 +885,8 @@ importInput.addEventListener('change', evt => {
     try {
       const data = JSON.parse(e.target.result);
       ingestLayout(data);
-      apply();
+      apply({ skipStatus: true });
+      showStatus('Layout imported from file.', 'success');
     } catch (err) {
       console.error('Failed to load layout', err);
       alert('Unable to parse layout file. Please ensure it is a valid export from the 2D survey.');
@@ -660,7 +895,59 @@ importInput.addEventListener('change', evt => {
   reader.readAsText(file);
 });
 
-applyDefaultPreset();
+if (saveBtn) {
+  saveBtn.addEventListener('click', async () => {
+    saveBtn.disabled = true;
+    try {
+      const snapshot = snapshotLayout();
+      persistLayoutLocal(snapshot);
+      const remoteOk = await saveLayoutRemote(snapshot);
+      showStatus(remoteOk ? 'Layout saved to server.' : 'Saved locally. Server unavailable?', remoteOk ? 'success' : 'warn');
+    } finally {
+      saveBtn.disabled = false;
+    }
+  });
+}
+
+if (loadBtn) {
+  loadBtn.addEventListener('click', async () => {
+    loadBtn.disabled = true;
+    try {
+      const restored = await restorePersistedLayout({ preferRemote: true });
+      if (restored) {
+        ingestLayout(restored.data);
+        apply({ skipStatus: true });
+        const tone = restored.source === 'server' ? 'success' : 'info';
+        const message = restored.source === 'server'
+          ? 'Layout loaded from server.'
+          : 'Layout loaded from this browser.';
+        showStatus(message, tone);
+      } else {
+        showStatus('No saved layout found yet.', 'warn');
+      }
+    } finally {
+      loadBtn.disabled = false;
+    }
+  });
+}
+
+async function initializeViewer() {
+  const restored = await restorePersistedLayout();
+  if (restored) {
+    ingestLayout(restored.data);
+    apply({ skipStatus: true });
+    const tone = restored.source === 'server' ? 'success' : 'info';
+    const message = restored.source === 'server'
+      ? 'Restored saved layout from server.'
+      : 'Restored layout from previous browser session.';
+    showStatus(message, tone);
+  } else {
+    applyDefaultPreset();
+    showStatus('Loaded demo preset layout.', 'info');
+  }
+}
+
+initializeViewer();
   </script>
 </body>
 </html>

--- a/dev/server.py
+++ b/dev/server.py
@@ -1,0 +1,136 @@
+"""Lightweight HTTP server for the room survey prototypes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler
+import socketserver
+from pathlib import Path
+from typing import Any, Tuple
+
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_STORE_PATH = BASE_DIR / "data" / "saved_layout.json"
+
+
+class LayoutStore:
+    """Persist layout JSON to a file on disk."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def read(self) -> Any:
+        if not self.path.exists():
+            return None
+        try:
+            raw = self.path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        if not raw.strip():
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+
+    def write(self, payload: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+class LayoutRequestHandler(SimpleHTTPRequestHandler):
+    """Serve static prototype assets and a small JSON API."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, directory=str(BASE_DIR), **kwargs)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        # Keep stdout noise low during tests.
+        return
+
+    def _json_response(self, payload: Any, status: HTTPStatus = HTTPStatus.OK) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _store(self) -> LayoutStore:
+        return self.server.layout_store  # type: ignore[attr-defined]
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.rstrip("?") == "/api/layout":
+            payload = {"layout": self._store().read()}
+            self._json_response(payload)
+            return
+        super().do_GET()
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path.rstrip("?") != "/api/layout":
+            self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8") if length else "{}"
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self._json_response({"error": "Invalid JSON body."}, HTTPStatus.BAD_REQUEST)
+            return
+
+        if not isinstance(payload, dict):
+            self._json_response(
+                {"error": "Expected JSON object."}, HTTPStatus.BAD_REQUEST
+            )
+            return
+
+        self._store().write(payload)
+        self._json_response({"status": "saved"})
+
+
+class LayoutHTTPServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        server_address: Tuple[str, int],
+        handler: type[LayoutRequestHandler],
+        store_path: Path,
+    ) -> None:
+        super().__init__(server_address, handler)
+        self.layout_store = LayoutStore(store_path)
+
+
+def run_server(
+    host: str = "0.0.0.0", port: int = 5000, store_path: Path | None = None
+) -> None:
+    """Run the threaded HTTP server until interrupted."""
+    store = store_path or DEFAULT_STORE_PATH
+    with LayoutHTTPServer((host, port), LayoutRequestHandler, store) as httpd:
+        print(f"Serving prototypes on http://{host}:{port}/ (layout store: {store})")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping server...")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Serve the room survey prototypes with persistence."
+    )
+    parser.add_argument("--host", default="0.0.0.0", help="Host/IP to bind")
+    parser.add_argument("--port", type=int, default=5000, help="Port to listen on")
+    parser.add_argument(
+        "--store",
+        type=Path,
+        default=DEFAULT_STORE_PATH,
+        help="Path to the JSON file used to persist layouts",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    run_server(host=args.host, port=args.port, store_path=args.store)

--- a/dev/shared/styles/glass_dark_theme.css
+++ b/dev/shared/styles/glass_dark_theme.css
@@ -1,0 +1,28 @@
+:root[data-room-theme="glass-dark"],
+body[data-room-theme="glass-dark"] {
+  --room-ui-bg: #0b1120;
+  --room-ui-text: #e2e8f0;
+  --room-ui-muted: rgba(148, 163, 184, 0.8);
+  --room-ui-muted-strong: rgba(203, 213, 225, 0.9);
+  --room-ui-surface: rgba(15, 23, 42, 0.82);
+  --room-ui-border: rgba(148, 163, 184, 0.2);
+  --room-ui-border-soft: rgba(148, 163, 184, 0.12);
+  --room-ui-link: #60a5fa;
+  --room-ui-button-border: rgba(148, 163, 184, 0.28);
+  --room-ui-button-bg-top: rgba(30, 41, 59, 0.88);
+  --room-ui-button-bg-bottom: rgba(15, 23, 42, 0.88);
+  --room-ui-shadow: rgba(8, 47, 73, 0.45);
+  --room-ui-overlay-bg: rgba(8, 15, 30, 0.82);
+  --room-ui-overlay-text: #e2e8f0;
+  --room-ui-overlay-shadow: rgba(30, 64, 175, 0.35);
+  --room-ui-info-bg: rgba(15, 23, 42, 0.7);
+  --room-ui-info-border: rgba(148, 163, 184, 0.16);
+  --room-ui-legend-text: rgba(226, 232, 240, 0.85);
+  --room-ui-legend-wall: #cbd5f5;
+  --room-ui-legend-custom: #fcd34d;
+  --room-ui-legend-door: #4ade80;
+  --room-ui-legend-floor: #60a5fa;
+  --room-ui-legend-asset: #c084fc;
+  --room-ui-viewport-bg: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.22), rgba(15, 23, 42, 0.92));
+  --room-ui-viewport-radial: rgba(59, 130, 246, 0.28);
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,89 @@
+import json
+import sys
+import threading
+import time
+from http.client import HTTPConnection
+from pathlib import Path
+from typing import Generator, Tuple, cast
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dev.server import LayoutHTTPServer, LayoutRequestHandler, LayoutStore  # noqa: E402
+
+
+@pytest.fixture
+def layout_store(tmp_path: Path) -> LayoutStore:
+    return LayoutStore(tmp_path / "layout.json")
+
+
+def test_store_round_trip(layout_store: LayoutStore) -> None:
+    assert layout_store.read() is None
+    payload = {"room": {"W": 7200, "L": 5400}, "floor_items": []}
+    layout_store.write(payload)
+    assert layout_store.read() == payload
+
+
+@pytest.fixture
+def running_server(
+    tmp_path: Path,
+) -> Generator[Tuple[str, int, LayoutHTTPServer], None, None]:
+    server = LayoutHTTPServer(
+        ("127.0.0.1", 0), LayoutRequestHandler, tmp_path / "layout.json"
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    # Small delay to ensure the server is ready before issuing requests.
+    time.sleep(0.05)
+    address = cast(Tuple[str, int], server.server_address)
+    host, port = address
+    try:
+        yield host, port, server
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+
+
+def test_http_api_round_trip(running_server) -> None:
+    host, port, server = running_server
+    conn = HTTPConnection(host, port, timeout=2)
+
+    conn.request("GET", "/api/layout")
+    response = conn.getresponse()
+    assert response.status == 200
+    data = json.loads(response.read().decode("utf-8"))
+    assert data == {"layout": None}
+
+    layout_payload = {
+        "room": {"W": 6400, "L": 8200},
+        "triangle": {"x": 1200, "y": 1800},
+    }
+    conn.request(
+        "POST",
+        "/api/layout",
+        body=json.dumps(layout_payload),
+        headers={"Content-Type": "application/json"},
+    )
+    post_response = conn.getresponse()
+    assert post_response.status == 200
+    assert json.loads(post_response.read().decode("utf-8")) == {"status": "saved"}
+
+    conn.request("GET", "/api/layout")
+    second_get = conn.getresponse()
+    assert second_get.status == 200
+    assert json.loads(second_get.read().decode("utf-8")) == {"layout": layout_payload}
+
+    conn.request(
+        "POST",
+        "/api/layout",
+        body=json.dumps([1, 2, 3]),
+        headers={"Content-Type": "application/json"},
+    )
+    invalid_response = conn.getresponse()
+    assert invalid_response.status == 400
+    assert "error" in json.loads(invalid_response.read().decode("utf-8"))
+
+    conn.close()


### PR DESCRIPTION
## Summary
- stabilize the orbit viewer navigation, apply the glass-dark styling, and surface status messaging
- add save/load controls with localStorage snapshots plus server-backed persistence hooks
- implement a threaded standard-library HTTP server with JSON layout endpoints and integration tests

## Testing
- pytest -q
- ruff check .
- black --check .
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68df047794648329bcc374b99342107e