### PR TITLE
Fix 3D layout import flow and apply glass-dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-10-02T23-43Z
+- fix: hardened orbit viewer imports to strip BOMs, unwrap nested payloads, and surface friendly errors when 2D exports are empty or malformed.
+- fix: restored the first-person demo by introducing a CDN-backed Three.js import map, applying the shared glass-dark theme, and sanitizing imported layout text.
+- feat: propagated the glass-dark backdrop to the landing page and 2D survey baseline for a consistent prototype suite aesthetic.
+- chore: noted the export/import regression workflow so a fresh 2D export loads instantly in both orbit and first-person demos.
+
 ## 2025-10-02T12-00
 - Added a shared landing page and unified navigation styling across the survey, orbit, and first-person demos using the glass light theme.
 - Preloaded the microscope room layout across 2D and 3D experiences, preventing delete-key conflicts while editing form controls.

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,3 @@
 # TODO
-
-✅ [p1] Audit `interactive_3d_room_v1.html` to stop the scene from "falling" on load by correcting any viewport sizing or camera animation issues.
-✅ [p1] Restore orbit viewer buttons (Apply/Home) so they reliably update the scene and camera without console errors.
-✅ [p1] Add explicit Save and Load controls that persist the latest room layout export for reuse after navigating away.
-✅ [p1] Stand up a minimal Python HTTP server (Flask alternative) to serve the prototype and expose JSON save/load endpoints backed by a local file store.
-✅ [p2] Apply the shared glass-light dark theme tokens to the orbit viewer layout so the styling matches the rest of the prototype suite.
-✅ [p2] Persist imported or edited layout data client-side so it reloads automatically when the viewer opens.
 🔲 [p3] Catalog reusable "glass light" theme tokens for other room survey prototypes and expand the shared theme library as new looks emerge.
 🔲 [p3] Evaluate additional camera input affordances (e.g., touch gestures and keyboard shortcuts) for the 3D first-person demo after the next round of feedback.

--- a/dev/index.html
+++ b/dev/index.html
@@ -5,9 +5,10 @@
   <title>Room Survey Prototype Suite</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="shared/styles/glass_light_theme.css" />
+  <link rel="stylesheet" href="shared/styles/glass_dark_theme.css" />
   <style>
     :root {
-      color-scheme: light;
+      color-scheme: dark;
     }
     * {
       box-sizing: border-box;
@@ -20,6 +21,18 @@
       display: grid;
       grid-template-rows: auto 1fr;
       min-height: 100vh;
+      position: relative;
+      overflow-x: hidden;
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(circle at 18% 16%, rgba(96, 165, 250, 0.2), transparent 45%),
+                  radial-gradient(circle at 84% 12%, rgba(129, 140, 248, 0.24), transparent 52%);
+      opacity: 0.82;
+      pointer-events: none;
+      z-index: -2;
     }
     header {
       display: flex;
@@ -127,7 +140,7 @@
     }
   </style>
 </head>
-<body>
+<body data-room-theme="glass-dark">
   <header>
     <div>
       <strong>Room Survey Prototype Suite</strong>

--- a/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
+++ b/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
@@ -5,9 +5,18 @@
   <title>Interactive 3D Room — First-Person Demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="../shared/styles/glass_light_theme.css" />
+  <link rel="stylesheet" href="../shared/styles/glass_dark_theme.css" />
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.159/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.159/examples/jsm/"
+      }
+    }
+  </script>
   <style>
     :root {
-      color-scheme: light dark;
+      color-scheme: dark;
     }
     * {
       box-sizing: border-box;
@@ -20,6 +29,18 @@
       min-height: 100vh;
       background: var(--room-ui-bg);
       color: var(--room-ui-text);
+      position: relative;
+      overflow-x: hidden;
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(circle at 18% 18%, rgba(96, 165, 250, 0.2), transparent 45%),
+                  radial-gradient(circle at 82% 12%, rgba(129, 140, 248, 0.24), transparent 52%);
+      opacity: 0.82;
+      pointer-events: none;
+      z-index: -2;
     }
     header {
       display: flex;
@@ -39,6 +60,11 @@
       gap: 12px;
       flex-wrap: wrap;
     }
+    header .subtitle {
+      font-size: 13px;
+      color: var(--room-ui-muted-strong);
+      margin-top: 2px;
+    }
     .nav-link {
       color: var(--room-ui-link);
       text-decoration: none;
@@ -57,6 +83,8 @@
       display: grid;
       grid-template-columns: minmax(260px, 340px) 1fr;
       min-height: 0;
+      position: relative;
+      z-index: 0;
     }
     aside {
       padding: 16px;
@@ -196,11 +224,11 @@
     }
   </style>
 </head>
-<body>
+<body data-room-theme="glass-dark">
   <header>
     <div>
       <strong>3D Room Viewer — First-Person Prototype</strong>
-      <div style="font-size:13px;color:rgba(31,41,51,0.68);">Walk inside the imported room layout, experiment with the FreeCAD <em>dozenSidedStack</em> sample, and preview placement in 3D.</div>
+      <div class="subtitle">Walk inside the imported room layout, experiment with the FreeCAD <em>dozenSidedStack</em> sample, and preview placement in 3D.</div>
     </div>
     <nav>
       <a class="nav-link" href="../index.html">Home</a>
@@ -256,10 +284,10 @@
   </main>
 
   <script type="module">
-    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.159/build/three.module.js';
-    import { PointerLockControls } from 'https://cdn.jsdelivr.net/npm/three@0.159/examples/jsm/controls/PointerLockControls.js';
-    import { TransformControls } from 'https://cdn.jsdelivr.net/npm/three@0.159/examples/jsm/controls/TransformControls.js';
-    import { X3DLoader } from 'https://cdn.jsdelivr.net/npm/three@0.159/examples/jsm/loaders/X3DLoader.js';
+    import * as THREE from 'three';
+    import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
+    import { TransformControls } from 'three/addons/controls/TransformControls.js';
+    import { X3DLoader } from 'three/addons/loaders/X3DLoader.js';
 
     const mm2m = value => value / 1000;
     const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
@@ -314,8 +342,20 @@
     const focusAssetBtn = document.getElementById('focusAsset');
     const roomInfo = document.getElementById('roomInfo');
 
+    function resolveThemeColor(variable, fallback) {
+      const styles = getComputedStyle(document.body);
+      const value = styles.getPropertyValue(variable);
+      return value ? value.trim() : fallback;
+    }
+
     const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0xf1f4f9);
+    let sceneBgColor = resolveThemeColor('--room-ui-bg', '#0b1120');
+    try {
+      scene.background = new THREE.Color(sceneBgColor);
+    } catch (err) {
+      console.warn('Failed to apply theme background color, falling back to default.', err);
+      scene.background = new THREE.Color('#0b1120');
+    }
 
     const camera = new THREE.PerspectiveCamera(65, 1, 0.1, 100);
     camera.position.set(0, 1.6, 5);
@@ -324,6 +364,7 @@
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.shadowMap.enabled = false;
+    renderer.setClearColor(scene.background);
     rendererHost.appendChild(renderer.domElement);
 
     const pointerControls = new PointerLockControls(camera, renderer.domElement);
@@ -484,6 +525,29 @@
         width: toNumber(door.width, 900),
         thickness: toNumber(door.thickness, DOOR_DEFAULT_THICKNESS_MM)
       };
+    }
+
+    function coerceLayoutPayload(raw) {
+      if (!raw || typeof raw !== 'object') return null;
+      if (raw.layout && typeof raw.layout === 'object') return raw.layout;
+      return raw;
+    }
+
+    function parseLayoutText(rawText) {
+      if (typeof rawText !== 'string') {
+        throw new Error('layout-file-empty');
+      }
+      const sanitized = rawText.replace(/^\uFEFF/, '').trim();
+      if (!sanitized) {
+        throw new Error('layout-file-empty');
+      }
+      try {
+        return coerceLayoutPayload(JSON.parse(sanitized));
+      } catch (err) {
+        const error = new Error('layout-file-invalid');
+        error.cause = err;
+        throw error;
+      }
     }
 
     function ensureLayoutIds() {
@@ -928,29 +992,28 @@
 
     focusAssetBtn.addEventListener('click', () => focusOnAsset());
 
-    layoutImport.addEventListener('change', event => {
-      const files = event.target && event.target.files;
-      const file = files && files[0];
-      if (!file) return;
-      const reader = new FileReader();
-      reader.onload = e => {
+    if (layoutImport) {
+      layoutImport.addEventListener('change', async event => {
+        const files = event.target && event.target.files;
+        const file = files && files[0];
+        if (!file) return;
         try {
-          const data = JSON.parse(e.target.result);
+          const text = await file.text();
+          const data = parseLayoutText(text);
+          if (!data) throw new Error('layout-file-empty');
           ingestLayout(data);
         } catch (err) {
           console.error('Failed to parse layout JSON', err);
-          alert('Unable to read layout file. Please export again from the 2D survey.');
+          const code = err && err.message;
+          const message = code === 'layout-file-empty'
+            ? 'The selected file was empty.'
+            : 'Unable to read layout file. Please export again from the 2D survey.';
+          alert(message);
         } finally {
           layoutImport.value = '';
         }
-      };
-      reader.onerror = err => {
-        console.error('Failed to load layout file', err);
-        alert('Unable to read layout file.');
-        layoutImport.value = '';
-      };
-      reader.readAsText(file);
-    });
+      });
+    }
 
     loadAssetBtn.addEventListener('click', () => {
       loadSampleAsset();

--- a/dev/interactive_3d_room/interactive_3d_room_v1.html
+++ b/dev/interactive_3d_room/interactive_3d_room_v1.html
@@ -448,6 +448,29 @@ async function loadLayoutRemote() {
   }
 }
 
+function coerceLayoutPayload(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  if (raw.layout && typeof raw.layout === 'object') return raw.layout;
+  return raw;
+}
+
+function parseLayoutText(rawText) {
+  if (typeof rawText !== 'string') {
+    throw new Error('layout-file-empty');
+  }
+  const sanitized = rawText.replace(/^\uFEFF/, '').trim();
+  if (!sanitized) {
+    throw new Error('layout-file-empty');
+  }
+  try {
+    return coerceLayoutPayload(JSON.parse(sanitized));
+  } catch (err) {
+    const error = new Error('layout-file-invalid');
+    error.cause = err;
+    throw error;
+  }
+}
+
 function snapshotLayout() {
   const triangle = layout.triangle || { x: 0, y: 0 };
   return {
@@ -877,23 +900,34 @@ homeBtn.addEventListener('click', () => {
   showStatus('Camera reset to home view.', 'info');
 });
 
-importInput.addEventListener('change', evt => {
-  const file = evt.target.files && evt.target.files[0];
-  if (!file) return;
-  const reader = new FileReader();
-  reader.onload = e => {
+if (importInput) {
+  importInput.addEventListener('change', async evt => {
     try {
-      const data = JSON.parse(e.target.result);
+      const file = evt.target.files && evt.target.files[0];
+      if (!file) return;
+      const text = await file.text();
+      const data = parseLayoutText(text);
+      if (!data) {
+        throw new Error('layout-file-empty');
+      }
       ingestLayout(data);
       apply({ skipStatus: true });
       showStatus('Layout imported from file.', 'success');
     } catch (err) {
       console.error('Failed to load layout', err);
-      alert('Unable to parse layout file. Please ensure it is a valid export from the 2D survey.');
+      const code = err && err.message;
+      const message = code === 'layout-file-empty'
+        ? 'The selected file was empty.'
+        : 'Unable to parse layout file. Please ensure it is a valid export from the 2D survey.';
+      showStatus(message, 'error');
+      alert(message);
+    } finally {
+      if (importInput) {
+        importInput.value = '';
+      }
     }
-  };
-  reader.readAsText(file);
-});
+  });
+}
 
 if (saveBtn) {
   saveBtn.addEventListener('click', async () => {

--- a/dev/room_survey_min/room_survey_min_v1.html
+++ b/dev/room_survey_min/room_survey_min_v1.html
@@ -6,9 +6,10 @@
   <title>Room Survey (SVG Drag + Snap) — v1 Baseline</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="../shared/styles/glass_light_theme.css" />
+  <link rel="stylesheet" href="../shared/styles/glass_dark_theme.css" />
   <style>
     :root {
-      color-scheme: light;
+      color-scheme: dark;
     }
     * {
       box-sizing: border-box;
@@ -21,6 +22,18 @@
       min-height: 100vh;
       display: grid;
       grid-template-rows: auto 1fr;
+      position: relative;
+      overflow-x: hidden;
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(circle at 18% 18%, rgba(96, 165, 250, 0.2), transparent 45%),
+                  radial-gradient(circle at 82% 14%, rgba(129, 140, 248, 0.24), transparent 52%);
+      opacity: 0.82;
+      pointer-events: none;
+      z-index: -2;
     }
     header {
       display: flex;
@@ -191,7 +204,7 @@
     }
   </style>
 </head>
-<body>
+<body data-room-theme="glass-dark">
   <header>
     <div>
       <strong>Room Survey (Top-Down)</strong>


### PR DESCRIPTION
## Summary
- harden both 3D viewers so layout imports strip BOMs, accept nested payloads, and surface friendlier errors
- add a Three.js import map and theme-driven background logic to the first-person demo while matching the glass-dark styling
- extend the glass-dark backdrop across the landing page and 2D survey baseline for a consistent suite aesthetic

## Testing
- pytest -q
- ruff check .
- black --check .
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68df0c7d3b3883298448e88e9c827016