### PR TITLE
Improve survey prototype server persistence and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-10-03T00:25Z
+- feat: complete step [p1] Create regression coverage for layout store resolution, environment overrides, and shutdown handling in tests/test_server.py.
+- fix: complete step [p1] Normalize dev/server.py store path resolution with env/CLI overrides and eagerly prepare the persistence directory.
+- fix: complete step [p1] Ensure CTRL+C shutdown invokes ThreadingTCPServer shutdown and runs on daemon worker threads for quick exit.
+- feat: complete step [p2] Emit structured logging for layout reads/saves and server lifecycle events via the apim_survey.server logger.
+- docs: complete step [p2] Document the APIM_SURVEY_LAYOUT_STORE override and logging behavior in dev/server.py.
+
 ## 2025-10-03T00:15Z
 - fix: ✅ [p1] Capture a reference 2D export and harden the orbit viewer importer by stripping BOM/null characters and logging nested parse errors.
 - fix: ✅ [p1] Wire the orbit viewer status banner to surface success/failure details when reloading the scene after imports.

--- a/dev/server.py
+++ b/dev/server.py
@@ -1,9 +1,22 @@
-"""Lightweight HTTP server for the room survey prototypes."""
+"""Lightweight HTTP server for the room survey prototypes.
+
+Environment variables
+---------------------
+``APIM_SURVEY_LAYOUT_STORE``
+    Optional absolute or relative path that overrides the layout persistence
+    location. Relative values are resolved against the current working
+    directory.
+
+The module emits informational logs via the ``apim_survey.server`` logger for
+startup, shutdown, and layout persistence events to aid troubleshooting.
+"""
 
 from __future__ import annotations
 
 import argparse
 import json
+import logging
+import os
 from http import HTTPStatus
 from http.server import SimpleHTTPRequestHandler
 import socketserver
@@ -12,6 +25,27 @@ from typing import Any, Tuple
 
 BASE_DIR = Path(__file__).resolve().parent
 DEFAULT_STORE_PATH = BASE_DIR / "data" / "saved_layout.json"
+ENV_STORE_PATH = "APIM_SURVEY_LAYOUT_STORE"
+
+
+LOGGER = logging.getLogger("apim_survey.server")
+
+
+def resolve_store_path(store_override: Path | None = None) -> Path:
+    """Resolve the effective layout store path with env and CLI overrides."""
+
+    if store_override is not None:
+        candidate = Path(store_override)
+    else:
+        env_value = os.getenv(ENV_STORE_PATH)
+        candidate = Path(env_value) if env_value else DEFAULT_STORE_PATH
+
+    candidate = candidate.expanduser()
+    if not candidate.is_absolute():
+        candidate = (Path.cwd() / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+    return candidate
 
 
 class LayoutStore:
@@ -19,24 +53,39 @@ class LayoutStore:
 
     def __init__(self, path: Path) -> None:
         self.path = path
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            LOGGER.error(
+                "Failed to prepare layout store directory %s: %s", self.path.parent, exc
+            )
 
     def read(self) -> Any:
         if not self.path.exists():
             return None
         try:
             raw = self.path.read_text(encoding="utf-8")
-        except OSError:
+        except OSError as exc:
+            LOGGER.warning("Unable to read layout store %s: %s", self.path, exc)
             return None
         if not raw.strip():
             return None
         try:
             return json.loads(raw)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
+            LOGGER.error("Failed to parse layout store %s: %s", self.path, exc)
             return None
 
     def write(self, payload: dict[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            LOGGER.error(
+                "Unable to create layout store directory %s: %s", self.path.parent, exc
+            )
+            raise
         self.path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        LOGGER.info("Layout saved to %s", self.path)
 
 
 class LayoutRequestHandler(SimpleHTTPRequestHandler):
@@ -46,8 +95,7 @@ class LayoutRequestHandler(SimpleHTTPRequestHandler):
         super().__init__(*args, directory=str(BASE_DIR), **kwargs)
 
     def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
-        # Keep stdout noise low during tests.
-        return
+        LOGGER.debug("HTTP %s", format % args)
 
     def _json_response(self, payload: Any, status: HTTPStatus = HTTPStatus.OK) -> None:
         data = json.dumps(payload).encode("utf-8")
@@ -64,6 +112,7 @@ class LayoutRequestHandler(SimpleHTTPRequestHandler):
         if self.path.rstrip("?") == "/api/layout":
             payload = {"layout": self._store().read()}
             self._json_response(payload)
+            LOGGER.info("Served layout read request")
             return
         super().do_GET()
 
@@ -78,20 +127,24 @@ class LayoutRequestHandler(SimpleHTTPRequestHandler):
             payload = json.loads(body)
         except json.JSONDecodeError:
             self._json_response({"error": "Invalid JSON body."}, HTTPStatus.BAD_REQUEST)
+            LOGGER.warning("Rejected layout save with invalid JSON")
             return
 
         if not isinstance(payload, dict):
             self._json_response(
                 {"error": "Expected JSON object."}, HTTPStatus.BAD_REQUEST
             )
+            LOGGER.warning("Rejected layout save with non-object payload")
             return
 
         self._store().write(payload)
         self._json_response({"status": "saved"})
+        LOGGER.info("Processed layout save request")
 
 
 class LayoutHTTPServer(socketserver.ThreadingTCPServer):
     allow_reuse_address = True
+    daemon_threads = True
 
     def __init__(
         self,
@@ -99,21 +152,27 @@ class LayoutHTTPServer(socketserver.ThreadingTCPServer):
         handler: type[LayoutRequestHandler],
         store_path: Path,
     ) -> None:
+        normalized_store = resolve_store_path(store_path)
         super().__init__(server_address, handler)
-        self.layout_store = LayoutStore(store_path)
+        self.layout_store = LayoutStore(normalized_store)
+        self.store_path = normalized_store
 
 
 def run_server(
     host: str = "127.0.0.1", port: int = 5000, store_path: Path | None = None
 ) -> None:
     """Run the threaded HTTP server until interrupted."""
-    store = store_path or DEFAULT_STORE_PATH
+    store = resolve_store_path(store_path)
+    LOGGER.info("Starting server on %s:%s with store %s", host, port, store)
     with LayoutHTTPServer((host, port), LayoutRequestHandler, store) as httpd:
         print(f"Serving prototypes on http://{host}:{port}/ (layout store: {store})")
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:
             print("\nStopping server...")
+            LOGGER.info("Shutdown requested by user")
+            httpd.shutdown()
+    LOGGER.info("Server stopped")
 
 
 def _parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- normalize the survey server layout store path resolution with CLI/env overrides and ensure the directory exists
- add structured logging, graceful shutdown, and daemon worker threads to the development server
- expand server regression coverage for path resolution, directory creation, and shutdown behavior

## Testing
- pytest -q
- ruff check .
- black --check .
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68df1759b84483298d40cc263211f00d