### PR TITLE
Fix orbit viewer namespace usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-10-03T00:58:56Z
+- fix: complete step [p1] Compare the orbit viewer markup against the working X3D MWE to pinpoint missing runtime namespace usage.
+- fix: complete step [p1] Refactor interactive_3d_room_v1.html to create X3D nodes with document.createElementNS so room geometry renders.
+- test: complete step [p1] Guard the namespace helper by asserting interactive_3d_room_v1.html references createX3DElement for key X3D tags.
+
 ## 2025-10-03T01:10Z
 - fix: complete step [p1] Investigate why the FPS viewer prototype was not persisting imported layouts and confirm server storage paths.
 - feat: complete step [p1] Implement layout persistence (local storage + server sync) for the FPS viewer and trigger it after imports and resets.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,8 @@
 TEST -- using AGENTS.md file
 # TODO
+✅ [p1] Compare the orbit viewer markup against resources/testObjects/dozenSidedStack/mwe_x3d_box.html to spot missing X3D runtime requirements.
+✅ [p1] Refactor dev/interactive_3d_room/interactive_3d_room_v1.html so dynamically created nodes use the proper X3D namespace helper.
+🔲 [p1] Manually smoke-test the orbit viewer preset after refactor to confirm walls, grid, and furniture render (blocked: requires local browser run).
 🔲 [p1] Verify the FPS viewer control buttons (Enter Walk Mode, Reset) wire up correctly after persistence changes.
 🔲 [p3] Catalog reusable "glass light" theme tokens for other room survey prototypes and expand the shared theme library as new looks emerge.
 🔲 [p3] Evaluate additional camera input affordances (e.g., touch gestures and keyboard shortcuts) for the 3D first-person demo after the next round of feedback.

--- a/dev/interactive_3d_room/interactive_3d_room_v1.html
+++ b/dev/interactive_3d_room/interactive_3d_room_v1.html
@@ -287,6 +287,12 @@
 
   <script>
 
+const X3D_NS = 'http://www.web3d.org/specifications/x3d-namespace';
+
+function createX3DElement(tagName) {
+  return document.createElementNS(X3D_NS, tagName);
+}
+
 const mm2m = v => v / 1000.0;
 const FT8_MM = 2438.4; // 8 feet
 const Hm = mm2m(FT8_MM);
@@ -634,7 +640,7 @@ function buildGrid(Wm, Lm) {
   }
   for (let x = 0; x <= spanX; x += 1) addLine([x, 0, 0], [x, 0, spanZ]);
   for (let z = 0; z <= spanZ; z += 1) addLine([0, 0, z], [spanX, 0, z]);
-  const coordEl = document.createElement('Coordinate');
+  const coordEl = createX3DElement('Coordinate');
   coordEl.setAttribute('point', coords.map(p => p.join(' ')).join(' '));
   while (gridLines.firstChild) gridLines.removeChild(gridLines.firstChild);
   gridLines.appendChild(coordEl);
@@ -654,14 +660,14 @@ function fitView(Wm, Lm, Hm) {
 }
 
 function createBoxShape(length, height, depth, color, transparency = 0.15) {
-  const shape = document.createElement('Shape');
-  const app = document.createElement('Appearance');
-  const material = document.createElement('Material');
+  const shape = createX3DElement('Shape');
+  const app = createX3DElement('Appearance');
+  const material = createX3DElement('Material');
   material.setAttribute('diffuseColor', color);
   material.setAttribute('transparency', transparency);
   app.appendChild(material);
   shape.appendChild(app);
-  const box = document.createElement('Box');
+  const box = createX3DElement('Box');
   box.setAttribute('size', `${Math.max(length, 0.01)} ${Math.max(height, 0.01)} ${Math.max(depth, 0.01)}`);
   shape.appendChild(box);
   return shape;
@@ -679,7 +685,7 @@ function renderWalls3d() {
     { length: Lm, thickness, x: Wm - thickness / 2, z: Lm / 2, rotation: Math.PI / 2 }
   ];
   baseWalls.forEach(w => {
-    const tf = document.createElement('Transform');
+    const tf = createX3DElement('Transform');
     tf.setAttribute('translation', `${w.x} ${Hm / 2} ${w.z}`);
     if (w.rotation) tf.setAttribute('rotation', `0 1 0 ${w.rotation}`);
     tf.appendChild(createBoxShape(w.length, Hm, w.thickness, WALL_COLOR, 0.25));
@@ -696,7 +702,7 @@ function renderWalls3d() {
     const length = mm2m(geom.length);
     const thick = mm2m(toNumber(wall.thickness, DEFAULT_WALL_THICKNESS_MM));
     const angle = Math.atan2(geom.tangent.y, geom.tangent.x);
-    const tf = document.createElement('Transform');
+    const tf = createX3DElement('Transform');
     tf.setAttribute('translation', `${center.x} ${Hm / 2} ${center.z}`);
     tf.setAttribute('rotation', `0 1 0 ${angle}`);
     tf.appendChild(createBoxShape(length, Hm, thick, CUSTOM_WALL_COLOR, 0.15));
@@ -718,7 +724,7 @@ function renderDoors3d() {
     const length = mm2m(Math.min(geom.length, Math.abs(door.width || 900)));
     const thick = mm2m(toNumber(door.thickness, DOOR_DEFAULT_THICKNESS_MM));
     const angle = Math.atan2(geom.tangent.y, geom.tangent.x);
-    const tf = document.createElement('Transform');
+    const tf = createX3DElement('Transform');
     tf.setAttribute('translation', `${center.x} ${DOOR_HEIGHT_M / 2} ${center.z}`);
     tf.setAttribute('rotation', `0 1 0 ${angle}`);
     tf.appendChild(createBoxShape(length, DOOR_HEIGHT_M, thick, DOOR_COLOR, 0.1));
@@ -736,7 +742,7 @@ function renderItems3d() {
     const h = meta.height || 0.8;
     const x = mm2m(toNumber(item.x, layout.room.Wmm / 2));
     const z = mm2m(toNumber(item.y, layout.room.Lmm / 2));
-    const tf = document.createElement('Transform');
+    const tf = createX3DElement('Transform');
     tf.setAttribute('translation', `${x} ${h / 2} ${z}`);
     const rot = toNumber(item.rotation, 0);
     if (rot) tf.setAttribute('rotation', `0 1 0 ${(rot * Math.PI) / 180}`);

--- a/tests/test_frontend_markup.py
+++ b/tests/test_frontend_markup.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_orbit_viewer_uses_x3d_namespace() -> None:
+    html_path = Path("dev/interactive_3d_room/interactive_3d_room_v1.html")
+    html = html_path.read_text(encoding="utf-8")
+
+    assert "createElementNS" in html
+
+    for tag in ["Coordinate", "Shape", "Appearance", "Material", "Box", "Transform"]:
+        assert f"createX3DElement('{tag}')" in html


### PR DESCRIPTION
## Summary
- ensure the orbit viewer builds X3D geometry using a shared createElementNS helper so the scene renders again
- document the investigation and refactor in TODO.md and CHANGELOG.md
- add a regression test that verifies the markup keeps using the namespace-aware helper

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df1f398bd8832984e950476c1cb853