### PR TITLE
fix: stabilize first-person walk mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-10-03T02:20:00Z
+- fix: complete step [p1] Trace why the FPS viewer walk/reset buttons stalled by surfacing pointer-lock failures, disabling walk mode when unsupported, and updating the HUD messaging.
+- fix: complete step [p1] Restore the first-person camera anchor by clearing move state on layout loads, pointer-lock unlocks, and resets so the scene stops drifting toward the viewer.
+- test: extend frontend markup checks to ensure the FPS demo ships the walk status element, resetMovementState helper, and pointer-lock error handler wiring.
+
 ## 2025-10-03T01:35:44Z
 - fix: complete step [p1] Reproduce the `default_room.json` import failure and harden the parser with a fallback slice so legacy exports no longer trigger the generic alert.
 - fix: complete step [p1] Update the orbit viewer loader to preserve furniture transforms by normalizing incoming layout payloads instead of resetting to presets.

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,9 @@ TEST -- using AGENTS.md file
 ✅ [p1] Reproduce the `default_room.json` layout load failure and capture console/network logs for the orbit viewer import.
 ✅ [p1] Update the orbit viewer loader so `default_room.json` rehydrates furniture transforms instead of resetting to the origin.
 ✅ [p1] Add a second tab in `dev/index.html` that mounts the existing MWE viewer with the shared survey theme applied.
-🔲 [p1] Verify the FPS viewer control buttons (Enter Walk Mode, Reset) wire up correctly after persistence changes.
+✅ [p1] Trace why the FPS viewer "Enter Walk Mode" and "Reset" buttons no longer activate and document the failing events.
+✅ [p1] Restore first-person controls so the camera stays anchored (no unintended forward drift) when loading room layouts.
 🔲 [p2] Extend regression tests to cover importing a saved layout and switching between tabs without losing state.
+🔲 [p2] Add an automated check that first-person mode stops moving when no input is pressed.
 🔲 [p3] Catalog reusable "glass light" theme tokens for other room survey prototypes and expand the shared theme library as new looks emerge.
 🔲 [p3] Evaluate additional camera input affordances (e.g., touch gestures and keyboard shortcuts) for the 3D first-person demo after the next round of feedback.

--- a/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
+++ b/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
@@ -108,6 +108,18 @@
       display: grid;
       gap: 8px;
     }
+    .controls .control-status {
+      font-size: 13px;
+      color: var(--room-ui-muted);
+      margin: 4px 0 0;
+      min-height: 1.2em;
+    }
+    .controls .control-status[data-tone="warn"] {
+      color: #facc15;
+    }
+    .controls .control-status[data-tone="success"] {
+      color: #34d399;
+    }
     label {
       display: grid;
       gap: 6px;
@@ -255,6 +267,7 @@
       <div class="controls">
         <button id="enterWalk">Enter Walk Mode</button>
         <button id="resetWalk">Reset Walk Position</button>
+        <p class="control-status" id="walkStatus" aria-live="polite"></p>
       </div>
       <div class="info-box" id="roomInfo"></div>
       <div class="info-box">
@@ -344,6 +357,10 @@
     const loadAssetBtn = document.getElementById('loadAsset');
     const focusAssetBtn = document.getElementById('focusAsset');
     const roomInfo = document.getElementById('roomInfo');
+    const walkStatus = document.getElementById('walkStatus');
+
+    const supportsPointerLock = typeof document !== 'undefined' && 'pointerLockElement' in document;
+    const POINTER_LOCK_UNSUPPORTED_MESSAGE = 'Pointer lock is unavailable in this browser. Try a desktop Chromium or Firefox build.';
 
     function resolveThemeColor(variable, fallback) {
       const styles = getComputedStyle(document.body);
@@ -410,6 +427,29 @@
     let assetLoaded = false;
     let assetSize = new THREE.Vector3(1, 1, 1);
     let selectedObject = null;
+
+    function resetMovementState() {
+      moveState.forward = false;
+      moveState.back = false;
+      moveState.left = false;
+      moveState.right = false;
+      moveState.up = false;
+      moveState.down = false;
+      velocity.set(0, 0, 0);
+      direction.set(0, 0, 0);
+    }
+
+    function setWalkStatus(message, tone = 'neutral') {
+      if (!walkStatus) return;
+      walkStatus.textContent = message;
+      walkStatus.dataset.tone = tone;
+    }
+
+    function updateWalkUi() {
+      const locked = pointerControls.isLocked;
+      if (enterWalkBtn) enterWalkBtn.disabled = locked || !supportsPointerLock;
+      if (resetWalkBtn) resetWalkBtn.disabled = false;
+    }
 
     function updateRendererSize() {
       const { clientWidth, clientHeight } = rendererHost;
@@ -724,6 +764,11 @@
       applyLayout();
       selectObject(null);
       persistLatest(persistOptions);
+      if (supportsPointerLock) {
+        setWalkStatus('Layout imported. Click “Enter Walk Mode” to explore.', 'neutral');
+      } else {
+        setWalkStatus(POINTER_LOCK_UNSUPPORTED_MESSAGE, 'warn');
+      }
     }
 
     function mmPointToWorld(xMm, yMm) {
@@ -887,14 +932,19 @@
       repositionAssetIfNeeded();
       updateRoomInfo();
       resetWalkPosition();
+      pointerControls.unlock();
+      resetMovementState();
+      updateWalkUi();
     }
 
     function resetWalkPosition() {
       const cameraHolder = pointerControls.getObject();
+      resetMovementState();
       cameraHolder.position.set(walkBounds.minX + 0.6, 1.6, walkBounds.minZ + 1.2);
       cameraHolder.rotation.set(0, 0, 0);
       camera.position.set(0, 0, 0);
       camera.rotation.set(0, 0, 0);
+      updateWalkUi();
     }
 
     function clampCamera() {
@@ -931,6 +981,7 @@
     }
 
     function onKeyDown(event) {
+      if (!pointerControls.isLocked) return;
       switch (event.code) {
         case 'KeyW': moveState.forward = true; break;
         case 'KeyS': moveState.back = true; break;
@@ -942,6 +993,7 @@
       }
     }
     function onKeyUp(event) {
+      if (!pointerControls.isLocked) return;
       switch (event.code) {
         case 'KeyW': moveState.forward = false; break;
         case 'KeyS': moveState.back = false; break;
@@ -958,9 +1010,29 @@
 
     pointerControls.addEventListener('lock', () => {
       walkOverlay.classList.add('hidden');
+      resetMovementState();
+      updateWalkUi();
+      setWalkStatus('Walk mode active — use WASD and your mouse to move. Press Esc to exit.', 'success');
     });
     pointerControls.addEventListener('unlock', () => {
       walkOverlay.classList.remove('hidden');
+      resetMovementState();
+      updateWalkUi();
+      setWalkStatus('Walk mode exited. Click “Enter Walk Mode” to continue exploring.', 'neutral');
+    });
+
+    document.addEventListener('pointerlockerror', event => {
+      console.warn('Pointer lock request failed', event);
+      walkOverlay.classList.remove('hidden');
+      resetMovementState();
+      updateWalkUi();
+      setWalkStatus('Pointer lock was blocked. Click inside the viewport first or open this demo in a standalone tab.', 'warn');
+    });
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        resetMovementState();
+      }
     });
 
     transformControls.addEventListener('dragging-changed', event => {
@@ -1093,6 +1165,7 @@
     renderer.domElement.addEventListener('pointercancel', endOrbit);
 
     function resetLayout(persistOptions = {}) {
+      pointerControls.unlock();
       const preset = DEFAULT_ROOM_PRESET();
       layout.room.Wmm = preset.room.W;
       layout.room.Lmm = preset.room.L;
@@ -1103,6 +1176,11 @@
       applyLayout();
       selectObject(null);
       persistLatest(persistOptions);
+      if (supportsPointerLock) {
+        setWalkStatus('Default layout loaded. Click “Enter Walk Mode” to explore.', 'neutral');
+      } else {
+        setWalkStatus(POINTER_LOCK_UNSUPPORTED_MESSAGE, 'warn');
+      }
     }
 
     function focusOnAsset() {
@@ -1119,6 +1197,10 @@
     }
 
     enterWalkBtn.addEventListener('click', () => {
+      if (!supportsPointerLock) {
+        setWalkStatus(POINTER_LOCK_UNSUPPORTED_MESSAGE, 'warn');
+        return;
+      }
       if (renderer.domElement && typeof renderer.domElement.focus === 'function') {
         try {
           renderer.domElement.focus();
@@ -1126,12 +1208,14 @@
           console.warn('Unable to focus renderer element before pointer lock', err);
         }
       }
+      setWalkStatus('Requesting pointer lock…');
       pointerControls.lock();
     });
 
     resetWalkBtn.addEventListener('click', () => {
       pointerControls.unlock();
       resetWalkPosition();
+      setWalkStatus('Walk position reset. Click “Enter Walk Mode” to re-enter.', 'neutral');
     });
 
     resetLayoutBtn.addEventListener('click', () => {

--- a/tests/test_frontend_markup.py
+++ b/tests/test_frontend_markup.py
@@ -21,3 +21,10 @@ def test_room_survey_references_layout_persistence() -> None:
     html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(encoding="utf-8")
     assert "LAYOUT_STORAGE_KEY" in html
     assert "/api/layout" in html
+
+
+def test_fps_viewer_handles_pointer_lock_state() -> None:
+    html = Path("dev/interactive_3d_room/interactive_3d_room_fps_demo.html").read_text(encoding="utf-8")
+    assert "class=\"control-status\"" in html
+    assert "function resetMovementState()" in html
+    assert "pointerlockerror" in html


### PR DESCRIPTION
## Summary
- add a persistent walk-mode status indicator and pointer-lock failure messaging to the FPS demo UI
- reset first-person movement state when layouts load or pointer lock changes so the camera no longer drifts toward the viewer
- extend the frontend markup test suite to assert the new walk-status markup and pointer-lock handlers are present

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df2d2303fc8329bb5b54c95908f159