### PR TITLE
Fix FPS module imports and snap resync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-10-03T03:45:00Z
+- fix: complete step [p1] Replace the FPS importmap with explicit Three.js module URLs so blocked importmaps no longer break the controls panel.
+- fix: complete step [p1] Point the FPS sample asset loader at `./dozenSidedStack-Body.x3d` so the sample import succeeds on hosted builds.
+- fix: complete step [p1] Add a resnapAll helper so changing the snap grid re-aligns existing survey geometry before re-rendering.
+
 ## 2025-10-03T02:20:00Z
 - fix: complete step [p1] Trace why the FPS viewer walk/reset buttons stalled by surfacing pointer-lock failures, disabling walk mode when unsupported, and updating the HUD messaging.
 - fix: complete step [p1] Restore the first-person camera anchor by clearing move state on layout loads, pointer-lock unlocks, and resets so the scene stops drifting toward the viewer.

--- a/PROBLEMS.md
+++ b/PROBLEMS.md
@@ -2,3 +2,4 @@
 - 2025-10-02: `pytest -q --maxfail=1 --cov=.` failed because `pytest-cov` is not installed in the environment. Reran the suite without the coverage flag once tests were configured.
 - 2025-10-02: `pip install flask` was blocked by the environment proxy (403). Replaced the Flask dependency with a standard-library HTTP server implementation instead.
 - 2025-10-03: `pytest -q --maxfail=1 --cov=.` still fails because the `pytest-cov` plugin is not installed in the environment. Reran the suite without the coverage flag.
+- 2025-10-03: `black --check .` flagged `tests/test_frontend_markup.py` formatting drift. Ran `black tests/test_frontend_markup.py` to restore compliance before rerunning the check.

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,8 @@
 TEST -- using AGENTS.md file
 # TODO
-✅ [p1] Reproduce the `default_room.json` layout load failure and capture console/network logs for the orbit viewer import.
-✅ [p1] Update the orbit viewer loader so `default_room.json` rehydrates furniture transforms instead of resetting to the origin.
-✅ [p1] Add a second tab in `dev/index.html` that mounts the existing MWE viewer with the shared survey theme applied.
-✅ [p1] Trace why the FPS viewer "Enter Walk Mode" and "Reset" buttons no longer activate and document the failing events.
-✅ [p1] Restore first-person controls so the camera stays anchored (no unintended forward drift) when loading room layouts.
 🔲 [p2] Extend regression tests to cover importing a saved layout and switching between tabs without losing state.
 🔲 [p2] Add an automated check that first-person mode stops moving when no input is pressed.
 🔲 [p3] Catalog reusable "glass light" theme tokens for other room survey prototypes and expand the shared theme library as new looks emerge.
 🔲 [p3] Evaluate additional camera input affordances (e.g., touch gestures and keyboard shortcuts) for the 3D first-person demo after the next round of feedback.
+🔲 [p2] Backfill regression coverage for the new FPS module loader path or document why automated coverage is deferred.
+🔲 [p3] Gate the FPS "Enter Walk Mode" button when pointer lock is unsupported and surface a toast to clarify the disabled state.

--- a/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
+++ b/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
@@ -6,14 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="../shared/styles/glass_light_theme.css" />
   <link rel="stylesheet" href="../shared/styles/glass_dark_theme.css" />
-  <script type="importmap">
-    {
-      "imports": {
-        "three": "https://cdn.jsdelivr.net/npm/three@0.159/build/three.module.js",
-        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.159/examples/jsm/"
-      }
-    }
-  </script>
   <style>
     :root {
       color-scheme: dark;
@@ -298,10 +290,10 @@
   </main>
 
   <script type="module">
-    import * as THREE from 'three';
-    import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
-    import { TransformControls } from 'three/addons/controls/TransformControls.js';
-    import { X3DLoader } from 'three/addons/loaders/X3DLoader.js';
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.159/build/three.module.js';
+    import { PointerLockControls } from 'https://cdn.jsdelivr.net/npm/three@0.159/examples/jsm/controls/PointerLockControls.js';
+    import { TransformControls } from 'https://cdn.jsdelivr.net/npm/three@0.159/examples/jsm/controls/TransformControls.js';
+    import { X3DLoader } from 'https://cdn.jsdelivr.net/npm/three@0.159/examples/jsm/loaders/X3DLoader.js';
 
     const mm2m = value => value / 1000;
     const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
@@ -1259,7 +1251,7 @@
     function loadSampleAsset() {
       loadAssetBtn.disabled = true;
       loader.load(
-        '../../resources/testObjects/dozenSidedStack/dozenSidedStack-Body.x3d',
+        './dozenSidedStack-Body.x3d',
         object => {
           const bbox = new THREE.Box3().setFromObject(object);
           const center = new THREE.Vector3();

--- a/dev/room_survey_min/room_survey_min_v1.html
+++ b/dev/room_survey_min/room_survey_min_v1.html
@@ -785,6 +785,29 @@ function snapPoint(pt) {
   return { x: snapValue(pt.x), y: snapValue(pt.y) };
 }
 
+function resnapAll() {
+  state.floorItems.forEach(item => {
+    if (typeof item.x === 'number') item.x = snapValue(item.x);
+    if (typeof item.y === 'number') item.y = snapValue(item.y);
+  });
+  state.wallItems.forEach(item => {
+    if (item.type === 'socket') {
+      if (typeof item.s === 'number') item.s = snapValue(item.s);
+      if (typeof item.h === 'number') item.h = snapValue(item.h);
+    }
+  });
+  state.customWalls.forEach(wall => {
+    if (typeof wall.x1 === 'number') wall.x1 = snapValue(wall.x1);
+    if (typeof wall.y1 === 'number') wall.y1 = snapValue(wall.y1);
+    if (typeof wall.x2 === 'number') wall.x2 = snapValue(wall.x2);
+    if (typeof wall.y2 === 'number') wall.y2 = snapValue(wall.y2);
+  });
+  state.doors.forEach(door => {
+    if (typeof door.offset === 'number') door.offset = snapValue(door.offset);
+    if (typeof door.width === 'number') door.width = snapValue(door.width);
+  });
+}
+
 function recomputeScale() {
   const maxWpx = 800, maxLpx = 520;
   const sx = maxWpx / state.Wmm;
@@ -1598,6 +1621,7 @@ applyBtn.addEventListener('click', () => {
   state.imperial = imperialChk.checked;
   state.snap = state.imperial ? 150 : Math.max(10, Number(snapInput.value || 100));
   snapInput.value = state.snap;
+  resnapAll();
   recomputeScale();
   clampStateToRoom();
   render();
@@ -1607,6 +1631,8 @@ imperialChk.addEventListener('change', () => {
   state.imperial = imperialChk.checked;
   state.snap = state.imperial ? 150 : Math.max(10, Number(snapInput.value || 100));
   snapInput.value = state.snap;
+  resnapAll();
+  clampStateToRoom();
   drawGrid();
   render();
 });
@@ -1614,6 +1640,8 @@ imperialChk.addEventListener('change', () => {
 snapInput.addEventListener('change', () => {
   if (state.imperial) return;
   state.snap = Math.max(10, Number(snapInput.value || 100));
+  resnapAll();
+  clampStateToRoom();
   drawGrid();
   render();
 });

--- a/tests/test_frontend_markup.py
+++ b/tests/test_frontend_markup.py
@@ -13,18 +13,22 @@ def test_orbit_viewer_uses_x3d_namespace() -> None:
 
 def test_home_nav_includes_mwe_tab() -> None:
     html = Path("dev/index.html").read_text(encoding="utf-8")
-    assert "href=\"test_objects/mwe_viewer.html\"" in html
+    assert 'href="test_objects/mwe_viewer.html"' in html
     assert ">MWE Viewer<" in html
 
 
 def test_room_survey_references_layout_persistence() -> None:
-    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(encoding="utf-8")
+    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
+        encoding="utf-8"
+    )
     assert "LAYOUT_STORAGE_KEY" in html
     assert "/api/layout" in html
 
 
 def test_fps_viewer_handles_pointer_lock_state() -> None:
-    html = Path("dev/interactive_3d_room/interactive_3d_room_fps_demo.html").read_text(encoding="utf-8")
-    assert "class=\"control-status\"" in html
+    html = Path("dev/interactive_3d_room/interactive_3d_room_fps_demo.html").read_text(
+        encoding="utf-8"
+    )
+    assert 'class="control-status"' in html
     assert "function resetMovementState()" in html
     assert "pointerlockerror" in html


### PR DESCRIPTION
## Summary
- load the FPS demo's Three.js dependencies via explicit CDN module URLs so the buttons work without importmap support
- correct the FPS sample asset path to point at the colocated X3D file
- resnap existing survey geometry when the snap spacing changes and document the change in the changelog

## Testing
- ruff check .
- black --check .
- mypy .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df32578e0c8329b54c3988843721ef