### PR TITLE
feat: sync cables across survey and fpv views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## 2025-10-04T15:29:44Z
+- feat: complete step [p1] Mirror 2D cable path edits into the FPV scene by ingesting storage updates and rebuilding Three.js tubes from the shared layout.
+- fix: complete step [p1] Remove plan-view clamps on cable handles and bend inserts while persisting absolute spline coordinates for out-of-bounds adjustments.
+- feat: complete step [p2] Add wall-mounted height controls to the survey UI and honor socket mount offsets when resolving cable anchors.
+- feat: complete step [p2] Retune default cable slack so sampled control handles sag toward the floor consistently across 2D and 3D renders.
+
 ## 2025-10-06T05:30:00Z
 - fix: complete step [p1] Wire orientation tab clicks to update the SVG data attribute so wall and ceiling projections replace the floor plan without losing selection context.
 - feat: complete step [p2] Gate the survey scale overlay behind a config flag and documentable tests so rulers render without blocking interactions.

--- a/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
+++ b/dev/interactive_3d_room/interactive_3d_room_fps_demo.html
@@ -326,6 +326,11 @@
     };
 
     const ROOM_HEIGHT_MM = 3000; // align with survey default (3 m)
+    const DEFAULT_WALL_MOUNT_HEIGHT_MM = 1200;
+    const CABLE_LATERAL_SLACK_RATIO = 0.25;
+    const CABLE_SAG_RATIO = 0.3;
+    const CABLE_SAG_MIN_MM = 150;
+    const CABLE_SAG_MAX_MM = 1200;
     const HUMAN_EYE_HEIGHT_M = 1.75; // ~5'9" eye level for first-person scale
     const DEFAULT_WALL_THICKNESS_MM = 200;
     const DOOR_DEFAULT_THICKNESS_MM = 80;
@@ -358,6 +363,7 @@
         assetKey: 'wall_socket',
         defaultDepthMm: 300,
         color: 0xf9a825,
+        mountHeightMm: 1200,
         sizeMm: { ...WALL_ITEM_DEFAULT_SIZE_MM },
         fallbackSockets: [
           {
@@ -375,6 +381,7 @@
         assetKey: 'wall_gas_socket',
         defaultDepthMm: 300,
         color: 0x22c55e,
+        mountHeightMm: 1400,
         sizeMm: { ...WALL_ITEM_DEFAULT_SIZE_MM },
         fallbackSockets: [
           {
@@ -392,6 +399,7 @@
         assetKey: 'wall_feedthrough',
         defaultDepthMm: 200,
         color: 0x0ea5e9,
+        mountHeightMm: 1300,
         sizeMm: { ...WALL_ITEM_DEFAULT_SIZE_MM },
         fallbackSockets: [
           {
@@ -880,12 +888,15 @@
       const type = typeof item.type === 'string' ? item.type : 'socket';
       const meta = WALL_ITEM_META[type] || WALL_ITEM_META.socket;
       const depth = item.h !== undefined ? item.h : meta.defaultDepthMm;
+      const mountSource = item.mount_height_mm ?? item.mountHeight_mm ?? item.mount_height ?? item.mountHeight;
+      const fallbackMount = meta.mountHeightMm !== undefined ? meta.mountHeightMm : DEFAULT_WALL_MOUNT_HEIGHT_MM;
       return {
         ...item,
         type,
         wall: wallRef || 'base:1',
         s: toNumber(item.s, 0),
-        h: toNumber(depth, meta.defaultDepthMm)
+        h: toNumber(depth, meta.defaultDepthMm),
+        mountHeight_mm: toNumber(mountSource !== undefined ? mountSource : fallbackMount, fallbackMount)
       };
     }
 
@@ -997,12 +1008,19 @@
               const u = Number(pt.u);
               const v = Number(pt.v);
               const w = Number(pt.w != null ? pt.w : pt.z);
-              if (!Number.isFinite(u) || !Number.isFinite(v)) return null;
-              return {
-                x: clamp(u, 0, 1) * layout.room.Wmm,
-                y: clamp(v, 0, 1) * layout.room.Lmm,
-                z: Number.isFinite(w) ? clamp(w, 0, 1) * ROOM_HEIGHT_MM : ROOM_HEIGHT_MM / 2
-              };
+              const xMm = Number(pt.x_mm);
+              const yMm = Number(pt.y_mm);
+              const zMm = Number(pt.z_mm);
+              const hasNormalized = Number.isFinite(u) && Number.isFinite(v);
+              const x = Number.isFinite(xMm) ? xMm : hasNormalized ? u * layout.room.Wmm : null;
+              const y = Number.isFinite(yMm) ? yMm : hasNormalized ? v * layout.room.Lmm : null;
+              const z = Number.isFinite(zMm)
+                ? zMm
+                : Number.isFinite(w)
+                  ? w * ROOM_HEIGHT_MM
+                  : ROOM_HEIGHT_MM / 2;
+              if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+              return { x, y, z };
             })
             .filter(Boolean)
         : [];
@@ -1013,12 +1031,19 @@
               const u = Number(pt.u);
               const v = Number(pt.v);
               const w = Number(pt.w != null ? pt.w : pt.z);
-              if (!Number.isFinite(u) || !Number.isFinite(v)) return null;
-              return {
-                x: clamp(u, 0, 1) * layout.room.Wmm,
-                y: clamp(v, 0, 1) * layout.room.Lmm,
-                z: Number.isFinite(w) ? clamp(w, 0, 1) * ROOM_HEIGHT_MM : ROOM_HEIGHT_MM / 2
-              };
+              const xMm = Number(pt.x_mm);
+              const yMm = Number(pt.y_mm);
+              const zMm = Number(pt.z_mm);
+              const hasNormalized = Number.isFinite(u) && Number.isFinite(v);
+              const x = Number.isFinite(xMm) ? xMm : hasNormalized ? u * layout.room.Wmm : null;
+              const y = Number.isFinite(yMm) ? yMm : hasNormalized ? v * layout.room.Lmm : null;
+              const z = Number.isFinite(zMm)
+                ? zMm
+                : Number.isFinite(w)
+                  ? w * ROOM_HEIGHT_MM
+                  : ROOM_HEIGHT_MM / 2;
+              if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+              return { x, y, z };
             })
             .filter(Boolean)
         : [];
@@ -1036,16 +1061,32 @@
     }
 
     function exportCableSnapshot(cable) {
-      const safePoints = (cable.controlPoints || []).map(pt => ({
-        u: clamp(pt.x / layout.room.Wmm, 0, 1),
-        v: clamp(pt.y / layout.room.Lmm, 0, 1),
-        w: clamp((pt.z || 0) / ROOM_HEIGHT_MM, 0, 1)
-      }));
-      const bendPoints = (cable.bendPoints || []).map(pt => ({
-        u: clamp(pt.x / layout.room.Wmm, 0, 1),
-        v: clamp(pt.y / layout.room.Lmm, 0, 1),
-        w: clamp((pt.z || 0) / ROOM_HEIGHT_MM, 0, 1)
-      }));
+      const safePoints = (cable.controlPoints || []).map(pt => {
+        const rawU = Number(pt.x) / layout.room.Wmm;
+        const rawV = Number(pt.y) / layout.room.Lmm;
+        const rawW = Number(pt.z || 0) / ROOM_HEIGHT_MM;
+        return {
+          u: Number.isFinite(rawU) ? rawU : 0,
+          v: Number.isFinite(rawV) ? rawV : 0,
+          w: Number.isFinite(rawW) ? rawW : 0,
+          x_mm: Number.isFinite(pt.x) ? pt.x : 0,
+          y_mm: Number.isFinite(pt.y) ? pt.y : 0,
+          z_mm: Number.isFinite(pt.z) ? pt.z : 0
+        };
+      });
+      const bendPoints = (cable.bendPoints || []).map(pt => {
+        const rawU = Number(pt.x) / layout.room.Wmm;
+        const rawV = Number(pt.y) / layout.room.Lmm;
+        const rawW = Number(pt.z || 0) / ROOM_HEIGHT_MM;
+        return {
+          u: Number.isFinite(rawU) ? rawU : 0,
+          v: Number.isFinite(rawV) ? rawV : 0,
+          w: Number.isFinite(rawW) ? rawW : 0,
+          x_mm: Number.isFinite(pt.x) ? pt.x : 0,
+          y_mm: Number.isFinite(pt.y) ? pt.y : 0,
+          z_mm: Number.isFinite(pt.z) ? pt.z : 0
+        };
+      });
       return {
         id: cable.id,
         cableType: cable.cableType,
@@ -1120,8 +1161,11 @@
           x: base.x + geom.normal.x * depth,
           y: base.y + geom.normal.y * depth
         };
+        const fallbackMount = meta.mountHeightMm !== undefined ? meta.mountHeightMm : DEFAULT_WALL_MOUNT_HEIGHT_MM;
+        const mountHeight = clamp(toNumber(item.mountHeight_mm, fallbackMount), 0, ROOM_HEIGHT_MM);
         const bboxHeight = meta.boundingBox_mm && meta.boundingBox_mm.h ? meta.boundingBox_mm.h : ROOM_HEIGHT_MM;
-        const height = bboxHeight * (anchor.w || 0.5);
+        const anchorOffset = (anchor.w != null ? anchor.w - 0.5 : 0) * bboxHeight;
+        const height = clamp(mountHeight + anchorOffset, 0, ROOM_HEIGHT_MM);
         return { x: tip.x, y: tip.y, z: height };
       }
       return null;
@@ -1157,8 +1201,12 @@
       const planarLength = Math.hypot(dx, dy) || 1;
       const nx = -dy / planarLength;
       const ny = dx / planarLength;
-      const slack = planarLength * 0.25;
-      const midZ = (startMm.z + endMm.z) / 2;
+      const slack = planarLength * CABLE_LATERAL_SLACK_RATIO;
+      const startZ = Number.isFinite(startMm.z) ? startMm.z : ROOM_HEIGHT_MM / 2;
+      const endZ = Number.isFinite(endMm.z) ? endMm.z : ROOM_HEIGHT_MM / 2;
+      const baseHeight = Math.min(startZ, endZ);
+      const sag = clamp(planarLength * CABLE_SAG_RATIO, CABLE_SAG_MIN_MM, CABLE_SAG_MAX_MM);
+      const midZ = Math.max(baseHeight - sag, 0);
       return [
         {
           x: startMm.x + dx * 0.25 + nx * slack,
@@ -1847,6 +1895,8 @@
         const width = mm2m(widthMm);
         const height = mm2m(heightMm);
         const depth = mm2m(extrudeMm);
+        const fallbackMount = meta.mountHeightMm !== undefined ? meta.mountHeightMm : DEFAULT_WALL_MOUNT_HEIGHT_MM;
+        const mountHeight = clamp(toNumber(item.mountHeight_mm, fallbackMount), 0, ROOM_HEIGHT_MM);
         const geometry = new THREE.BoxGeometry(width, height, depth);
         const material = new THREE.MeshStandardMaterial({
           color: meta.color || 0xf9a825,
@@ -1854,7 +1904,7 @@
           metalness: 0.12
         });
         const mesh = new THREE.Mesh(geometry, material);
-        mesh.position.set(world.x, mm2m(heightMm / 2), world.z);
+        mesh.position.set(world.x, mm2m(mountHeight), world.z);
         mesh.rotation.y = -Math.atan2(geom.tangent.y, geom.tangent.x);
         mesh.userData.wallItemId = item.id;
         wallItemGroup.add(mesh);
@@ -2494,11 +2544,39 @@
       });
     }
 
+    let pendingStorageSync = null;
+
+    async function ingestLayoutFromSerialized(raw, options = {}) {
+      try {
+        const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        const data = coerceLayoutPayload(parsed);
+        if (data) {
+          await ingestLayout(data, options);
+        }
+      } catch (err) {
+        console.warn('Failed to ingest layout from storage event', err);
+      }
+    }
+
+    function handleLayoutStorageEvent(event) {
+      if (!event || event.key !== LAYOUT_STORAGE_KEY) return;
+      if (event.storageArea && event.storageArea !== window.localStorage) return;
+      if (!event.newValue) return;
+      if (pendingStorageSync) {
+        clearTimeout(pendingStorageSync);
+      }
+      pendingStorageSync = window.setTimeout(() => {
+        pendingStorageSync = null;
+        ingestLayoutFromSerialized(event.newValue, { local: false, remote: false });
+      }, 80);
+    }
+
     function onWindowResize() {
       updateRendererSize();
     }
 
     window.addEventListener('resize', onWindowResize);
+    window.addEventListener('storage', handleLayoutStorageEvent);
 
     resetLayout({ local: false, remote: false });
     updateRendererSize();

--- a/dev/room_survey_min/room_survey_min_v1.html
+++ b/dev/room_survey_min/room_survey_min_v1.html
@@ -682,6 +682,22 @@ function normalizeFloorItemFromLayout(item) {
   };
 }
 
+function getWallItemMountHeight(item) {
+  if (!item) return DEFAULT_WALL_MOUNT_HEIGHT_MM;
+  const def = WALL_ITEM_DEFS[item.type] || WALL_ITEM_DEFS.socket;
+  const fallback = def.mountHeightMm !== undefined ? def.mountHeightMm : DEFAULT_WALL_MOUNT_HEIGHT_MM;
+  const source = typeof item.mountHeight_mm === 'number'
+    ? item.mountHeight_mm
+    : typeof item.mount_height_mm === 'number'
+      ? item.mount_height_mm
+      : typeof item.mountHeight === 'number'
+        ? item.mountHeight
+        : typeof item.mount_height === 'number'
+          ? item.mount_height
+          : fallback;
+  return clamp(toNumber(source, fallback), 0, DEFAULT_ROOM_HEIGHT_MM);
+}
+
 function normalizeWallItemFromLayout(item) {
   if (!item || typeof item !== 'object') return null;
   const type = item.type || 'socket';
@@ -691,13 +707,6 @@ function normalizeWallItemFromLayout(item) {
   if (typeof wallRef === 'number') wallRef = `base:${wallRef}`;
   if (typeof wallRef === 'string' && /^\d$/.test(wallRef)) wallRef = `base:${wallRef}`;
   const depth = item.h !== undefined ? item.h : def.defaultDepth;
-  const mountHeightSource =
-    item.mount_height_mm !== undefined ? item.mount_height_mm
-    : item.mountHeight_mm !== undefined ? item.mountHeight_mm
-    : item.mount_height !== undefined ? item.mount_height
-    : item.mountHeight !== undefined ? item.mountHeight
-      : undefined;
-  const fallbackMount = def.mountHeightMm !== undefined ? def.mountHeightMm : 1200;
   const normalized = {
     id,
     type,
@@ -705,10 +714,9 @@ function normalizeWallItemFromLayout(item) {
     s: toNumber(item.s, 0),
     h: toNumber(depth, def.defaultDepth)
   };
-  if (mountHeightSource !== undefined) {
-    normalized.mountHeight_mm = toNumber(mountHeightSource, fallbackMount);
-  } else if (def.mountHeightMm !== undefined) {
-    normalized.mountHeight_mm = def.mountHeightMm;
+  const mountHeight = getWallItemMountHeight({ ...item, type });
+  if (Number.isFinite(mountHeight)) {
+    normalized.mountHeight_mm = mountHeight;
   }
   return normalized;
 }
@@ -1594,6 +1602,43 @@ function defaultHudMessage() {
   return `${snapStr} | Selected: ${sel}`;
 }
 
+function applySelectedWallItemMountHeight(heightMm) {
+  if (!state.selectedSurface || state.selectedSurface.type !== 'wallItem') return;
+  const item = state.wallItems.find(w => w.id === state.selectedSurface.id);
+  if (!item) return;
+  const def = WALL_ITEM_DEFS[item.type] || WALL_ITEM_DEFS.socket;
+  const clamped = clamp(Number(heightMm) || 0, 0, DEFAULT_ROOM_HEIGHT_MM);
+  const snapped = snapValue(clamped);
+  if (item.mountHeight_mm === snapped) return;
+  item.mountHeight_mm = snapped;
+  showHud(`Set ${def.label} height to ${fmtLen(snapped)}.`);
+  render();
+}
+
+function updateWallItemControls() {
+  if (!wallItemControlsEl) return;
+  const selected = state.selectedSurface && state.selectedSurface.type === 'wallItem'
+    ? state.wallItems.find(w => w.id === state.selectedSurface.id)
+    : null;
+  const def = selected ? WALL_ITEM_DEFS[selected.type] || WALL_ITEM_DEFS.socket : null;
+  const mountHeight = selected ? getWallItemMountHeight(selected) : DEFAULT_WALL_MOUNT_HEIGHT_MM;
+  const message = selected
+    ? `${def ? def.label : 'Wall item'} height ${fmtLen(mountHeight)}`
+    : 'Select a wall-mounted item to edit its mount height.';
+  if (wallItemSelectionNoteEl) {
+    wallItemSelectionNoteEl.textContent = message;
+  }
+  const sliderValue = Math.round(mountHeight);
+  if (wallItemMountSliderEl) {
+    wallItemMountSliderEl.disabled = !selected;
+    wallItemMountSliderEl.value = `${sliderValue}`;
+  }
+  if (wallItemMountInputEl) {
+    wallItemMountInputEl.disabled = !selected;
+    wallItemMountInputEl.value = `${sliderValue}`;
+  }
+}
+
 function render() {
   updateWallSelect();
   const type = orientationType();
@@ -1608,6 +1653,7 @@ function render() {
   }
   updateOrientationActiveState();
   renderScaleOverlay();
+  updateWallItemControls();
   hud.textContent = hudTransient || defaultHudMessage();
   hudTransient = null;
   maybePersistLayout();
@@ -2741,7 +2787,26 @@ const FALLBACK_CABLE_COLORS = (function () {
   return colors;
 })();
 const DEFAULT_ROOM_HEIGHT_MM = 3000;
+const DEFAULT_WALL_MOUNT_HEIGHT_MM = 1200;
 const CABLE_SAMPLE_SEGMENTS = 48;
+const CABLE_LATERAL_SLACK_RATIO = 0.25;
+const CABLE_SAG_RATIO = 0.3;
+const CABLE_SAG_MIN_MM = 150;
+const CABLE_SAG_MAX_MM = 1200;
+const WALL_ITEM_CONTROLS_TEMPLATE = `
+      <div class="panel" id="wallItemControls">
+        <h3>Wall Item Details</h3>
+        <div class="note" id="wallItemSelectionNote">Select a wall-mounted item to edit its mount height.</div>
+        <label>
+          Adjust mount height
+          <input type="range" id="wallItemMountHeightSlider" min="0" max="${DEFAULT_ROOM_HEIGHT_MM}" step="10" disabled>
+        </label>
+        <label>
+          Mount height (mm)
+          <input type="number" id="wallItemMountHeight" min="0" max="${DEFAULT_ROOM_HEIGHT_MM}" step="10" disabled>
+        </label>
+      </div>
+`;
 const CABLE_CONTROLS_TEMPLATE = `
       <div class="panel" id="cableControls">
         <h3>Service Cables</h3>
@@ -2758,6 +2823,10 @@ const CABLE_CONTROLS_TEMPLATE = `
       </div>
 `;
 
+let wallItemControlsEl = null;
+let wallItemMountInputEl = null;
+let wallItemMountSliderEl = null;
+let wallItemSelectionNoteEl = null;
 let cableTypeSelectEl = null;
 let cancelCableBtnEl = null;
 let deleteCableBtnEl = null;
@@ -2932,8 +3001,10 @@ function resolveSocketPosition(ref) {
       x: base.x + geom.normal.x * depth,
       y: base.y + geom.normal.y * depth
     };
+    const mountHeight = getWallItemMountHeight(item);
     const heightBasis = meta.boundingBox_mm && meta.boundingBox_mm.h ? meta.boundingBox_mm.h : DEFAULT_ROOM_HEIGHT_MM;
-    const height = heightBasis * (anchor.w || 0.5);
+    const anchorOffset = (anchor.w != null ? anchor.w - 0.5 : 0) * heightBasis;
+    const height = clamp(mountHeight + anchorOffset, 0, DEFAULT_ROOM_HEIGHT_MM);
     return { x: tip.x, y: tip.y, z: height };
   }
   return null;
@@ -2967,8 +3038,12 @@ function defaultHandlesForSegment(start, end) {
   const length = Math.hypot(dx, dy) || 1;
   const nx = -dy / length;
   const ny = dx / length;
-  const slack = length * 0.25;
-  const midZ = (start.z + end.z) / 2;
+  const slack = length * CABLE_LATERAL_SLACK_RATIO;
+  const startZ = Number.isFinite(start.z) ? start.z : DEFAULT_ROOM_HEIGHT_MM / 2;
+  const endZ = Number.isFinite(end.z) ? end.z : DEFAULT_ROOM_HEIGHT_MM / 2;
+  const baseHeight = Math.min(startZ, endZ);
+  const sag = clamp(length * CABLE_SAG_RATIO, CABLE_SAG_MIN_MM, CABLE_SAG_MAX_MM);
+  const midZ = Math.max(baseHeight - sag, 0);
   return [
     {
       x: start.x + dx * 0.25 + nx * slack,
@@ -3060,16 +3135,32 @@ function updateCableMetrics(cable, start, end) {
 }
 
 function exportCableToSnapshot(cable) {
-  const safePoints = (cable.controlPoints || []).map(pt => ({
-    u: clamp(pt.x / state.Wmm, 0, 1),
-    v: clamp(pt.y / state.Lmm, 0, 1),
-    w: clamp((pt.z || 0) / DEFAULT_ROOM_HEIGHT_MM, 0, 1)
-  }));
-  const bendPoints = (cable.bendPoints || []).map(pt => ({
-    u: clamp(pt.x / state.Wmm, 0, 1),
-    v: clamp(pt.y / state.Lmm, 0, 1),
-    w: clamp((pt.z || 0) / DEFAULT_ROOM_HEIGHT_MM, 0, 1)
-  }));
+  const safePoints = (cable.controlPoints || []).map(pt => {
+    const rawU = Number(pt.x) / state.Wmm;
+    const rawV = Number(pt.y) / state.Lmm;
+    const rawW = Number(pt.z || 0) / DEFAULT_ROOM_HEIGHT_MM;
+    return {
+      u: Number.isFinite(rawU) ? rawU : 0,
+      v: Number.isFinite(rawV) ? rawV : 0,
+      w: Number.isFinite(rawW) ? rawW : 0,
+      x_mm: Number.isFinite(pt.x) ? pt.x : 0,
+      y_mm: Number.isFinite(pt.y) ? pt.y : 0,
+      z_mm: Number.isFinite(pt.z) ? pt.z : 0
+    };
+  });
+  const bendPoints = (cable.bendPoints || []).map(pt => {
+    const rawU = Number(pt.x) / state.Wmm;
+    const rawV = Number(pt.y) / state.Lmm;
+    const rawW = Number(pt.z || 0) / DEFAULT_ROOM_HEIGHT_MM;
+    return {
+      u: Number.isFinite(rawU) ? rawU : 0,
+      v: Number.isFinite(rawV) ? rawV : 0,
+      w: Number.isFinite(rawW) ? rawW : 0,
+      x_mm: Number.isFinite(pt.x) ? pt.x : 0,
+      y_mm: Number.isFinite(pt.y) ? pt.y : 0,
+      z_mm: Number.isFinite(pt.z) ? pt.z : 0
+    };
+  });
   return {
     id: cable.id,
     cableType: cable.cableType,
@@ -3119,12 +3210,19 @@ function normalizeCableFromLayout(entry) {
           const u = Number(pt.u);
           const v = Number(pt.v);
           const w = Number(pt.w != null ? pt.w : pt.z);
-          if (!Number.isFinite(u) || !Number.isFinite(v)) return null;
-          return {
-            x: clamp(u, 0, 1) * state.Wmm,
-            y: clamp(v, 0, 1) * state.Lmm,
-            z: Number.isFinite(w) ? clamp(w, 0, 1) * DEFAULT_ROOM_HEIGHT_MM : 0
-          };
+          const xMm = Number(pt.x_mm);
+          const yMm = Number(pt.y_mm);
+          const zMm = Number(pt.z_mm);
+          const hasNormalized = Number.isFinite(u) && Number.isFinite(v);
+          const x = Number.isFinite(xMm) ? xMm : hasNormalized ? u * state.Wmm : null;
+          const y = Number.isFinite(yMm) ? yMm : hasNormalized ? v * state.Lmm : null;
+          const z = Number.isFinite(zMm)
+            ? zMm
+            : Number.isFinite(w)
+              ? w * DEFAULT_ROOM_HEIGHT_MM
+              : 0;
+          if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+          return { x, y, z };
         })
         .filter(Boolean)
     : [];
@@ -3135,12 +3233,19 @@ function normalizeCableFromLayout(entry) {
           const u = Number(pt.u);
           const v = Number(pt.v);
           const w = Number(pt.w != null ? pt.w : pt.z);
-          if (!Number.isFinite(u) || !Number.isFinite(v)) return null;
-          return {
-            x: clamp(u, 0, 1) * state.Wmm,
-            y: clamp(v, 0, 1) * state.Lmm,
-            z: Number.isFinite(w) ? clamp(w, 0, 1) * DEFAULT_ROOM_HEIGHT_MM : 0
-          };
+          const xMm = Number(pt.x_mm);
+          const yMm = Number(pt.y_mm);
+          const zMm = Number(pt.z_mm);
+          const hasNormalized = Number.isFinite(u) && Number.isFinite(v);
+          const x = Number.isFinite(xMm) ? xMm : hasNormalized ? u * state.Wmm : null;
+          const y = Number.isFinite(yMm) ? yMm : hasNormalized ? v * state.Lmm : null;
+          const z = Number.isFinite(zMm)
+            ? zMm
+            : Number.isFinite(w)
+              ? w * DEFAULT_ROOM_HEIGHT_MM
+              : 0;
+          if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+          return { x, y, z };
         })
         .filter(Boolean)
     : [];
@@ -3492,11 +3597,11 @@ function insertCableBendPoint(cable, approxPoint) {
   const end = resolveSocketPosition(cable.target);
   if (!start || !end) return false;
   const snapped = snapPoint(approxPoint);
-  const clamped = clampPointToRoom(snapped);
+  const rawPoint = snapped;
   let insertIndex = Array.isArray(cable.bendPoints) ? cable.bendPoints.length : 0;
   let finalPoint = {
-    x: clamped.x,
-    y: clamped.y,
+    x: rawPoint.x,
+    y: rawPoint.y,
     z: (start.z + end.z) / 2
   };
   const cache = cableCurveCache.get(cable.id);
@@ -3505,7 +3610,7 @@ function insertCableBendPoint(cable, approxPoint) {
   if (samples.length > 0 && anchors.length > 1) {
     let best = null;
     samples.forEach(sample => {
-      const dist = distance2d(clamped, sample.point);
+      const dist = distance2d(rawPoint, sample.point);
       if (!best || dist < best.dist) {
         best = { dist, sample };
       }
@@ -3519,16 +3624,16 @@ function insertCableBendPoint(cable, approxPoint) {
       const c2 = cable.controlPoints[seg * 2 + 1];
       const precise = cubicPoint(best.sample.t, p0, c1, c2, p3);
       finalPoint = {
-        x: clamp(precise.x, 0, state.Wmm),
-        y: clamp(precise.y, 0, state.Lmm),
+        x: precise.x,
+        y: precise.y,
         z: Number.isFinite(precise.z) ? precise.z : finalPoint.z
       };
     }
   }
   const snappedFinal = snapPoint(finalPoint);
   const bendPoint = {
-    x: clamp(snappedFinal.x, 0, state.Wmm),
-    y: clamp(snappedFinal.y, 0, state.Lmm),
+    x: snappedFinal.x,
+    y: snappedFinal.y,
     z: finalPoint.z
   };
   if (!Array.isArray(cable.bendPoints)) cable.bendPoints = [];
@@ -3538,6 +3643,37 @@ function insertCableBendPoint(cable, approxPoint) {
   showHud('Added bend point.');
   return true;
 }
+
+ (function setupWallItemControls() {
+  const aside = document.querySelector('aside');
+  if (!aside) return;
+  aside.insertAdjacentHTML('beforeend', WALL_ITEM_CONTROLS_TEMPLATE);
+  wallItemControlsEl = document.getElementById('wallItemControls');
+  wallItemMountInputEl = document.getElementById('wallItemMountHeight');
+  wallItemMountSliderEl = document.getElementById('wallItemMountHeightSlider');
+  wallItemSelectionNoteEl = document.getElementById('wallItemSelectionNote');
+  if (wallItemMountSliderEl) {
+    wallItemMountSliderEl.addEventListener('input', evt => {
+      const value = Number(evt.target.value);
+      if (!Number.isFinite(value)) return;
+      if (wallItemMountInputEl) {
+        wallItemMountInputEl.value = `${Math.round(value)}`;
+      }
+      applySelectedWallItemMountHeight(value);
+    });
+  }
+  if (wallItemMountInputEl) {
+    wallItemMountInputEl.addEventListener('change', evt => {
+      const value = Number(evt.target.value);
+      if (!Number.isFinite(value)) return;
+      if (wallItemMountSliderEl) {
+        wallItemMountSliderEl.value = `${Math.round(value)}`;
+      }
+      applySelectedWallItemMountHeight(value);
+    });
+  }
+  updateWallItemControls();
+})();
 
 (function setupCablePrototype() {
   const aside = document.querySelector('aside');
@@ -3691,7 +3827,10 @@ function insertCableBendPoint(cable, approxPoint) {
     const cable = state.cables.find(c => c.id === drag.cableId);
     if (!cable) return;
     const pt = svgPoint(evt);
-    const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
+    const rawRoomPt = svgPointToRoomMm(pt);
+    const roomPt = drag.kind === 'cable-handle' || drag.kind === 'cable-bend'
+      ? rawRoomPt
+      : clampPointToRoom(rawRoomPt);
     const snapped = snapPoint(roomPt);
     if (drag.kind === 'cable-handle') {
       const handle = cable.controlPoints[drag.handleIndex];

--- a/tests/test_frontend_markup.py
+++ b/tests/test_frontend_markup.py
@@ -186,3 +186,42 @@ def test_fps_viewer_uses_human_scale_height_and_markers() -> None:
     assert "function createLabelSprite" in html
     assert "const HUMAN_EYE_HEIGHT_M" in html
     assert "camera.position.set(0, HUMAN_EYE_HEIGHT_M, 5);" in html
+
+
+def test_room_survey_exposes_wall_mount_height_controls() -> None:
+    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'id="wallItemControls"' in html
+    assert 'id="wallItemMountHeight"' in html
+    assert 'id="wallItemMountHeightSlider"' in html
+    assert "function updateWallItemControls" in html
+
+
+def test_room_survey_exports_unclamped_cable_points() -> None:
+    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "const rawU = Number(pt.x) / state.Wmm;" in html
+    assert "const rawV = Number(pt.y) / state.Lmm;" in html
+    assert "const rawW = Number(pt.z || 0) / DEFAULT_ROOM_HEIGHT_MM;" in html
+
+
+def test_fps_viewer_syncs_layout_storage_updates() -> None:
+    html = Path("dev/interactive_3d_room/interactive_3d_room_fps_demo.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "function handleLayoutStorageEvent" in html
+    assert "window.addEventListener('storage', handleLayoutStorageEvent);" in html
+
+
+def test_fps_viewer_respects_wall_mount_heights() -> None:
+    html = Path("dev/interactive_3d_room/interactive_3d_room_fps_demo.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "mountHeight_mm" in html
+    assert "const fallbackMount" in html


### PR DESCRIPTION
## Summary
- add wall item mount-height controls and slack tuning in the 2D survey so cables sag naturally and handles can extend beyond the room bounds
- persist absolute cable spline coordinates and refresh the FPV scene via storage events to mirror survey edits, including updated wall socket heights
- extend frontend markup tests and changelog coverage for the new controls, serialization changes, and FPV sync behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e13a1ea55083299abd31a2b2e8a77e