### PR TITLE
Align wall elevation snapping with floor view and ground cable defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 2025-10-04T17:06:49Z
+- feat: complete step [p1] Align wall elevation drag interactions with the shared floor snap pipeline so wall tab edits honor snap increments and HUD feedback.
+- feat: complete step [p1] Rework default cable sag so untouched splines drop to the floor quickly and track the 2D path via updated control point defaults and markup tests.
+
 ## 2025-10-04T15:29:44Z
 - feat: complete step [p1] Mirror 2D cable path edits into the FPV scene by ingesting storage updates and rebuilding Three.js tubes from the shared layout.
 - fix: complete step [p1] Remove plan-view clamps on cable handles and bend inserts while persisting absolute spline coordinates for out-of-bounds adjustments.

--- a/dev/room_survey_min/room_survey_min_v1.html
+++ b/dev/room_survey_min/room_survey_min_v1.html
@@ -1792,6 +1792,9 @@ function renderWallOrientation() {
     if (isSelected) {
       group.dataset.selected = 'true';
     }
+    group.dataset.wallItemId = item.id;
+    group.style.cursor = 'grab';
+    group.addEventListener('pointerdown', handleWallElevationDragStart);
 
     const stem = document.createElementNS('http://www.w3.org/2000/svg', 'line');
     stem.setAttribute('x1', basePt[0]);
@@ -2325,6 +2328,32 @@ function handleSocketHeightDragStart(evt) {
   evt.preventDefault();
 }
 
+function handleWallElevationDragStart(evt) {
+  if (!isWallOrientation()) return;
+  const target = evt.currentTarget;
+  const id = target && target.dataset ? target.dataset.wallItemId : null;
+  if (!id) return;
+  const item = state.wallItems.find(w => w.id === id);
+  if (!item) return;
+  const view = state.view;
+  if (!view || view.type !== 'wall' || !view.wallGeom || view.wallGeom.ref !== item.wall) return;
+  setSelectedSurface({ type: 'wallItem', id }, { skipRender: true });
+  const pt = svgPoint(evt);
+  const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
+  const mountHeight = getWallItemMountHeight(item);
+  drag = {
+    kind: 'wall-elevation-item',
+    id,
+    wallRef: item.wall,
+    offsetX: roomPt.x - item.s,
+    offsetY: roomPt.y - mountHeight,
+    captureEl: svg,
+    pointerId: evt.pointerId
+  };
+  svg.setPointerCapture(evt.pointerId);
+  evt.preventDefault();
+}
+
 function handleCustomWallLineDown(evt) {
   if (!isPlanViewActive()) return;
   const wallId = evt.currentTarget.dataset.wallId;
@@ -2382,7 +2411,8 @@ function handleDoorDragStart(evt) {
 
 document.addEventListener('pointermove', evt => {
   if (!drag) return;
-  if (!isPlanViewActive()) return;
+  const isWallDrag = drag.kind === 'wall-elevation-item';
+  if (!isPlanViewActive() && !isWallDrag) return;
   const pt = svgPoint(evt);
   const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
   if (drag.kind === 'floor') {
@@ -2456,6 +2486,21 @@ document.addEventListener('pointermove', evt => {
     const center = clamp(centerSnapped, half, maxCenter);
     door.offset = clamp(center - half, 0, Math.max(0, geom.length - door.width));
     showHud(`Door position ${fmtLen(center)} along ${geom.label}`);
+    render();
+  } else if (drag.kind === 'wall-elevation-item') {
+    const item = state.wallItems.find(w => w.id === drag.id);
+    if (!item) return;
+    const view = state.view;
+    if (!view || view.type !== 'wall' || !view.wallGeom || item.wall !== drag.wallRef) return;
+    const def = WALL_ITEM_DEFS[item.type] || WALL_ITEM_DEFS.socket;
+    const nextOffset = snapValue(roomPt.x - drag.offsetX);
+    const nextHeight = snapValue(roomPt.y - drag.offsetY);
+    const offset = clamp(nextOffset, 0, view.widthMm);
+    const height = clamp(nextHeight, 0, view.heightMm);
+    item.s = offset;
+    item.mountHeight_mm = height;
+    const wallLabel = view.wallGeom.label || 'Wall';
+    showHud(`${def.label} @ ${fmtLen(offset)} · height ${fmtLen(height)} on ${wallLabel}`);
     render();
   }
 });
@@ -2789,10 +2834,9 @@ const FALLBACK_CABLE_COLORS = (function () {
 const DEFAULT_ROOM_HEIGHT_MM = 3000;
 const DEFAULT_WALL_MOUNT_HEIGHT_MM = 1200;
 const CABLE_SAMPLE_SEGMENTS = 48;
-const CABLE_LATERAL_SLACK_RATIO = 0.25;
-const CABLE_SAG_RATIO = 0.3;
-const CABLE_SAG_MIN_MM = 150;
-const CABLE_SAG_MAX_MM = 1200;
+const GROUND_Z_MM = 0;
+const CABLE_DROP_FRACTION = 0.2;
+const CABLE_DROP_MAX_MM = 450;
 const WALL_ITEM_CONTROLS_TEMPLATE = `
       <div class="panel" id="wallItemControls">
         <h3>Wall Item Details</h3>
@@ -3036,26 +3080,21 @@ function defaultHandlesForSegment(start, end) {
   const dx = end.x - start.x;
   const dy = end.y - start.y;
   const length = Math.hypot(dx, dy) || 1;
-  const nx = -dy / length;
-  const ny = dx / length;
-  const slack = length * CABLE_LATERAL_SLACK_RATIO;
   const startZ = Number.isFinite(start.z) ? start.z : DEFAULT_ROOM_HEIGHT_MM / 2;
   const endZ = Number.isFinite(end.z) ? end.z : DEFAULT_ROOM_HEIGHT_MM / 2;
-  const baseHeight = Math.min(startZ, endZ);
-  const sag = clamp(length * CABLE_SAG_RATIO, CABLE_SAG_MIN_MM, CABLE_SAG_MAX_MM);
-  const midZ = Math.max(baseHeight - sag, 0);
-  return [
-    {
-      x: start.x + dx * 0.25 + nx * slack,
-      y: start.y + dy * 0.25 + ny * slack,
-      z: midZ
-    },
-    {
-      x: start.x + dx * 0.75 + nx * slack,
-      y: start.y + dy * 0.75 + ny * slack,
-      z: midZ
-    }
-  ];
+  const dropRatio = length > 0 ? Math.min(CABLE_DROP_FRACTION, CABLE_DROP_MAX_MM / length) : 0;
+  const approachT = clamp(dropRatio, 0.1, 0.45);
+  const handle1 = {
+    x: start.x + dx * approachT,
+    y: start.y + dy * approachT,
+    z: startZ > GROUND_Z_MM ? GROUND_Z_MM : startZ
+  };
+  const handle2 = {
+    x: end.x - dx * approachT,
+    y: end.y - dy * approachT,
+    z: endZ > GROUND_Z_MM ? GROUND_Z_MM : endZ
+  };
+  return [handle1, handle2];
 }
 
 function ensureCableControlPoints(cable, start, end, forceDefaults = false) {

--- a/tests/test_frontend_markup.py
+++ b/tests/test_frontend_markup.py
@@ -154,6 +154,16 @@ def test_room_survey_provides_wall_elevation_and_scale_overlay() -> None:
     assert "const SCALE_OVERLAY_CONFIG" in html
 
 
+def test_wall_elevation_uses_shared_snap_drag_pipeline() -> None:
+    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "function handleWallElevationDragStart" in html
+    assert "drag.kind === 'wall-elevation-item'" in html
+    assert "snapValue(roomPt.x - drag.offsetX)" in html
+
+
 def test_room_survey_updates_svg_orientation_attribute() -> None:
     html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
         encoding="utf-8"
@@ -207,6 +217,16 @@ def test_room_survey_exports_unclamped_cable_points() -> None:
     assert "const rawU = Number(pt.x) / state.Wmm;" in html
     assert "const rawV = Number(pt.y) / state.Lmm;" in html
     assert "const rawW = Number(pt.z || 0) / DEFAULT_ROOM_HEIGHT_MM;" in html
+
+
+def test_cable_defaults_drop_to_ground_run() -> None:
+    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "const GROUND_Z_MM = 0;" in html
+    assert "const CABLE_DROP_FRACTION" in html
+    assert "const CABLE_DROP_MAX_MM" in html
 
 
 def test_fps_viewer_syncs_layout_storage_updates() -> None:


### PR DESCRIPTION
## Summary
- mirror wall elevation dragging onto the shared snap pipeline so wall edits behave like floor view interactions and surface consistent HUD messaging
- bias default cable control points toward quick floor drops and ground-level runs and document the change in the changelog
- extend frontend markup tests to pin the new wall drag handler hooks and cable grounding constants

## Testing
- pytest -q
- ruff check .
- black --check .
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68e152b4d9b883299038bc1711246cf0