### PR TITLE
feat: align wall elevation drag snapping with floor pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 2025-10-06T19:15:00Z
+- feat: complete step [p1] Restore wall elevation drag snapping with the shared floor pipeline and remove the legacy mount height panel.
+- test: add drag snap module coverage plus markup checks for the shared snap import and wall HUD updates.
+
 ## 2025-10-06T12:45:00Z
 - feat: complete step [p2] Add wall and ceiling thermostat assets with catalog metadata, ceiling plan overlays, and FPV hanging sensor meshes plus regression coverage.
 - feat: complete step [p2] Define catalog entries for chiller, N2 bottle, wall air barb, bottled air line, and resizable tables with shared defaults across 2D and FPV views.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,10 @@
 TEST -- using AGENTS.md file
 # TODO
+✅ [p1] Restore wall elevation drag snapping to match the floor snap pipeline and retire the legacy mount height panel.
+  - [x] Audit wall tab drag handlers to find where snap increments diverge from floor logic and note reuse opportunities.
+  - [x] Refactor wall drag interactions to reuse the shared snap utility so vertical moves quantize to snap spacing and emit HUD feedback.
+  - [x] Remove or hide the "Wall Item Details" height panel when drag snapping is active, guarding with tests for both behaviors.
+  - [x] Add regression coverage verifying wall-mounted items drag-snap to expected heights and HUD updates show snap increments.
 ✅ [p2] Extend regression tests to cover importing a saved layout and switching between orientation tabs without losing state.
   - [x] Capture a layout export fixture containing floor and wall placements plus cables.
   - [x] Write a survey store test that loads the fixture, flips tabs, and asserts selection/cable context persists.

--- a/dev/room_survey_min/drag_snap.js
+++ b/dev/room_survey_min/drag_snap.js
@@ -1,0 +1,40 @@
+export function snapValue(value, snap) {
+  const step = Number(snap);
+  if (!Number.isFinite(step) || step <= 0) {
+    return value;
+  }
+  const scaled = value / step;
+  const rounded = Math.round(scaled);
+  return rounded * step;
+}
+
+export function snapPoint(point, snap) {
+  const src = point || {};
+  return {
+    x: snapValue(Number(src.x) || 0, snap),
+    y: snapValue(Number(src.y) || 0, snap),
+  };
+}
+
+export function clampScalar(value, min = -Infinity, max = Infinity) {
+  let next = value;
+  if (Number.isFinite(min)) {
+    next = Math.max(min, next);
+  }
+  if (Number.isFinite(max)) {
+    next = Math.min(max, next);
+  }
+  return next;
+}
+
+export function applyDragSnap({ pointer, offsets, snap, limits }) {
+  const src = pointer || {};
+  const offset = offsets || {};
+  const bounds = limits || {};
+  const quantizedX = snapValue((Number(src.x) || 0) - (Number(offset.x) || 0), snap);
+  const quantizedY = snapValue((Number(src.y) || 0) - (Number(offset.y) || 0), snap);
+  return {
+    x: clampScalar(quantizedX, bounds.minX, bounds.maxX),
+    y: clampScalar(quantizedY, bounds.minY, bounds.maxY),
+  };
+}

--- a/dev/room_survey_min/room_survey_min_v1.html
+++ b/dev/room_survey_min/room_survey_min_v1.html
@@ -530,6 +530,7 @@
       parseOrientationKey,
       snapshotOrientation,
     } from './orientation_helpers.js';
+    import { applyDragSnap, snapPoint, snapValue } from './drag_snap.js';
 
 const bodyEl = document.body;
 const svg = document.getElementById('stage');
@@ -927,8 +928,8 @@ function applyDefaultPreset() {
       if (!normalized) return null;
       return {
         ...normalized,
-        x: snapValue(normalized.x),
-        y: snapValue(normalized.y)
+        x: snapValue(normalized.x, state.snap),
+        y: snapValue(normalized.y, state.snap)
       };
     })
     .filter(Boolean);
@@ -1344,41 +1345,31 @@ function fmtLen(mm) {
   return `${Math.round(mm)} mm (${inches.toFixed(2)} in)`;
 }
 
-function snapValue(vmm) {
-  const s = state.snap;
-  if (!s) return vmm;
-  return Math.round(vmm / s) * s;
-}
-
 function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
-
-function snapPoint(pt) {
-  return { x: snapValue(pt.x), y: snapValue(pt.y) };
-}
 
 function resnapAll() {
   state.floorItems.forEach(item => {
-    if (typeof item.x === 'number') item.x = snapValue(item.x);
-    if (typeof item.y === 'number') item.y = snapValue(item.y);
+    if (typeof item.x === 'number') item.x = snapValue(item.x, state.snap);
+    if (typeof item.y === 'number') item.y = snapValue(item.y, state.snap);
   });
   state.wallItems.forEach(item => {
     if (WALL_ITEM_DEFS[item.type]) {
-      if (typeof item.s === 'number') item.s = snapValue(item.s);
-      if (typeof item.h === 'number') item.h = snapValue(item.h);
+      if (typeof item.s === 'number') item.s = snapValue(item.s, state.snap);
+      if (typeof item.h === 'number') item.h = snapValue(item.h, state.snap);
       if (typeof item.mountHeight_mm === 'number') {
-        item.mountHeight_mm = snapValue(item.mountHeight_mm);
+        item.mountHeight_mm = snapValue(item.mountHeight_mm, state.snap);
       }
     }
   });
   state.customWalls.forEach(wall => {
-    if (typeof wall.x1 === 'number') wall.x1 = snapValue(wall.x1);
-    if (typeof wall.y1 === 'number') wall.y1 = snapValue(wall.y1);
-    if (typeof wall.x2 === 'number') wall.x2 = snapValue(wall.x2);
-    if (typeof wall.y2 === 'number') wall.y2 = snapValue(wall.y2);
+    if (typeof wall.x1 === 'number') wall.x1 = snapValue(wall.x1, state.snap);
+    if (typeof wall.y1 === 'number') wall.y1 = snapValue(wall.y1, state.snap);
+    if (typeof wall.x2 === 'number') wall.x2 = snapValue(wall.x2, state.snap);
+    if (typeof wall.y2 === 'number') wall.y2 = snapValue(wall.y2, state.snap);
   });
   state.doors.forEach(door => {
-    if (typeof door.offset === 'number') door.offset = snapValue(door.offset);
-    if (typeof door.width === 'number') door.width = snapValue(door.width);
+    if (typeof door.offset === 'number') door.offset = snapValue(door.offset, state.snap);
+    if (typeof door.width === 'number') door.width = snapValue(door.width, state.snap);
   });
 }
 
@@ -1895,43 +1886,6 @@ function defaultHudMessage() {
   return `${snapStr} | Selected: ${sel}`;
 }
 
-function applySelectedWallItemMountHeight(heightMm) {
-  if (!state.selectedSurface || state.selectedSurface.type !== 'wallItem') return;
-  const item = state.wallItems.find(w => w.id === state.selectedSurface.id);
-  if (!item) return;
-  const def = WALL_ITEM_DEFS[item.type] || WALL_ITEM_DEFS.socket;
-  const clamped = clamp(Number(heightMm) || 0, 0, DEFAULT_ROOM_HEIGHT_MM);
-  const snapped = snapValue(clamped);
-  if (item.mountHeight_mm === snapped) return;
-  item.mountHeight_mm = snapped;
-  showHud(`Set ${def.label} height to ${fmtLen(snapped)}.`);
-  render();
-}
-
-function updateWallItemControls() {
-  if (!wallItemControlsEl) return;
-  const selected = state.selectedSurface && state.selectedSurface.type === 'wallItem'
-    ? state.wallItems.find(w => w.id === state.selectedSurface.id)
-    : null;
-  const def = selected ? WALL_ITEM_DEFS[selected.type] || WALL_ITEM_DEFS.socket : null;
-  const mountHeight = selected ? getWallItemMountHeight(selected) : DEFAULT_WALL_MOUNT_HEIGHT_MM;
-  const message = selected
-    ? `${def ? def.label : 'Wall item'} height ${fmtLen(mountHeight)}`
-    : 'Select a wall-mounted item to edit its mount height.';
-  if (wallItemSelectionNoteEl) {
-    wallItemSelectionNoteEl.textContent = message;
-  }
-  const sliderValue = Math.round(mountHeight);
-  if (wallItemMountSliderEl) {
-    wallItemMountSliderEl.disabled = !selected;
-    wallItemMountSliderEl.value = `${sliderValue}`;
-  }
-  if (wallItemMountInputEl) {
-    wallItemMountInputEl.disabled = !selected;
-    wallItemMountInputEl.value = `${sliderValue}`;
-  }
-}
-
 function render() {
   updateWallSelect();
   const type = orientationType();
@@ -1947,7 +1901,6 @@ function render() {
   updateOrientationActiveState();
   renderScaleOverlay();
   renderInventoryTable();
-  updateWallItemControls();
   hud.textContent = hudTransient || defaultHudMessage();
   hudTransient = null;
   maybePersistLayout();
@@ -2742,7 +2695,7 @@ function handleCustomWallLineDown(evt) {
   if (!wall) return;
   const pt = svgPoint(evt);
   const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
-  const snapped = snapPoint(roomPt);
+  const snapped = snapPoint(roomPt, state.snap);
   drag = {
     kind: 'wall-move',
     wallId,
@@ -2764,7 +2717,7 @@ function handleWallHandleDown(evt) {
   setSelectedSurface({ type: 'wall', ref: `custom:${wallId}` }, { skipRender: true });
   const pt = svgPoint(evt);
   const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
-  const snapped = snapPoint(roomPt);
+  const snapped = snapPoint(roomPt, state.snap);
   drag = {
     kind: 'wall-handle',
     wallId,
@@ -2797,10 +2750,14 @@ document.addEventListener('pointermove', evt => {
   if (drag.kind === 'floor') {
     const item = state.floorItems.find(f => f.id === drag.id);
     if (!item) return;
-    const newX = snapValue(roomPt.x - drag.offsetX);
-    const newY = snapValue(roomPt.y - drag.offsetY);
-    item.x = clamp(newX, 0, state.Wmm);
-    item.y = clamp(newY, 0, state.Lmm);
+    const snapped = applyDragSnap({
+      pointer: roomPt,
+      offsets: { x: drag.offsetX, y: drag.offsetY },
+      snap: state.snap,
+      limits: { minX: 0, maxX: state.Wmm, minY: 0, maxY: state.Lmm }
+    });
+    item.x = snapped.x;
+    item.y = snapped.y;
     showHud(`${FLOOR_ITEM_DEFS[item.type]?.label || 'Item'} @ (${fmtLen(item.x)}, ${fmtLen(item.y)})`);
     render();
   } else if (drag.kind === 'socketS') {
@@ -2809,7 +2766,7 @@ document.addEventListener('pointermove', evt => {
     const geom = getWallGeometry(item.wall);
     if (!geom) return;
     const proj = projectPointOntoWall(geom, roomPt);
-    item.s = snapValue(proj.s);
+    item.s = snapValue(proj.s, state.snap);
     const def = WALL_ITEM_DEFS[item.type] || WALL_ITEM_DEFS.socket;
     showHud(`${def.label} offset ${fmtLen(item.s)} on ${geom.label}`);
     render();
@@ -2820,7 +2777,7 @@ document.addEventListener('pointermove', evt => {
     if (!geom) return;
     const proj = projectPointOntoWall(geom, roomPt);
     const standoff = clamp(Math.abs(proj.distance), 0, 4000);
-    item.h = snapValue(standoff);
+    item.h = snapValue(standoff, state.snap);
     const def = WALL_ITEM_DEFS[item.type] || WALL_ITEM_DEFS.socket;
     showHud(`${def.label} standoff ${fmtLen(item.h)} on ${geom.label}`);
     render();
@@ -2829,8 +2786,8 @@ document.addEventListener('pointermove', evt => {
     if (!wall) return;
     const dx = roomPt.x - drag.start.x;
     const dy = roomPt.y - drag.start.y;
-    const start = snapPoint({ x: drag.orig.x1 + dx, y: drag.orig.y1 + dy });
-    const end = snapPoint({ x: drag.orig.x2 + dx, y: drag.orig.y2 + dy });
+    const start = snapPoint({ x: drag.orig.x1 + dx, y: drag.orig.y1 + dy }, state.snap);
+    const end = snapPoint({ x: drag.orig.x2 + dx, y: drag.orig.y2 + dy }, state.snap);
     const clampStart = clampPointToRoom(start);
     const clampEnd = clampPointToRoom(end);
     wall.x1 = clampStart.x;
@@ -2842,7 +2799,7 @@ document.addEventListener('pointermove', evt => {
   } else if (drag.kind === 'wall-handle') {
     const wall = getCustomWallById(drag.wallId);
     if (!wall) return;
-    const snapped = snapPoint(roomPt);
+    const snapped = snapPoint(roomPt, state.snap);
     const clamped = clampPointToRoom(snapped);
     if (drag.handle === 'start') {
       wall.x1 = clamped.x;
@@ -2861,7 +2818,7 @@ document.addEventListener('pointermove', evt => {
     const proj = projectPointOntoWall(geom, roomPt);
     const half = door.width / 2;
     const maxCenter = Math.max(half, geom.length - half);
-    const centerSnapped = snapValue(proj.s);
+    const centerSnapped = snapValue(proj.s, state.snap);
     const center = clamp(centerSnapped, half, maxCenter);
     door.offset = clamp(center - half, 0, Math.max(0, geom.length - door.width));
     showHud(`Door position ${fmtLen(center)} along ${geom.label}`);
@@ -2872,14 +2829,16 @@ document.addEventListener('pointermove', evt => {
     const view = state.view;
     if (!view || view.type !== 'wall' || !view.wallGeom || item.wall !== drag.wallRef) return;
     const def = WALL_ITEM_DEFS[item.type] || WALL_ITEM_DEFS.socket;
-    const nextOffset = snapValue(roomPt.x - drag.offsetX);
-    const nextHeight = snapValue(roomPt.y - drag.offsetY);
-    const offset = clamp(nextOffset, 0, view.widthMm);
-    const height = clamp(nextHeight, 0, view.heightMm);
-    item.s = offset;
-    item.mountHeight_mm = height;
+    const snapped = applyDragSnap({
+      pointer: roomPt,
+      offsets: { x: drag.offsetX, y: drag.offsetY },
+      snap: state.snap,
+      limits: { minX: 0, maxX: view.widthMm, minY: 0, maxY: view.heightMm }
+    });
+    item.s = snapped.x;
+    item.mountHeight_mm = snapped.y;
     const wallLabel = view.wallGeom.label || 'Wall';
-    showHud(`${def.label} @ ${fmtLen(offset)} · height ${fmtLen(height)} on ${wallLabel}`);
+    showHud(`${def.label} @ ${fmtLen(item.s)} · height ${fmtLen(item.mountHeight_mm)} on ${wallLabel}`);
     render();
   }
 });
@@ -2964,11 +2923,11 @@ svg.addEventListener('pointerdown', evt => {
   const pt = svgPoint(evt);
   const roomPt = clampPointToRoom(svgPointToRoomMm(pt));
   if (!drawWallState.start) {
-    drawWallState.start = snapPoint(roomPt);
+    drawWallState.start = snapPoint(roomPt, state.snap);
     showHud('Select second point for new wall');
   } else {
     const start = drawWallState.start;
-    const end = snapPoint(roomPt);
+    const end = snapPoint(roomPt, state.snap);
     if (Math.hypot(end.x - start.x, end.y - start.y) > 10) {
       const wall = {
         id: genId('wall'),
@@ -3039,8 +2998,8 @@ basicAddBtn.addEventListener('click', () => {
   const item = {
     id: genId('floor'),
     type,
-    x: snapValue(state.Wmm / 2),
-    y: snapValue(state.Lmm / 2),
+    x: snapValue(state.Wmm / 2, state.snap),
+    y: snapValue(state.Lmm / 2, state.snap),
     w: def.w,
     l: def.l,
     rotation: 0
@@ -3062,11 +3021,11 @@ addBtn.addEventListener('click', () => {
       showHud('Select a wall before adding wall items');
       return;
     }
-    const s = snapValue(geom.length / 2);
-    const depth = snapValue(def.defaultDepth);
+    const s = snapValue(geom.length / 2, state.snap);
+    const depth = snapValue(def.defaultDepth, state.snap);
     const mountHeight = def.mountHeightMm !== undefined
-      ? snapValue(def.mountHeightMm)
-      : snapValue(1200);
+      ? snapValue(def.mountHeightMm, state.snap)
+      : snapValue(1200, state.snap);
     const item = {
       id: genId(def.idPrefix || 'wallItem'),
       type,
@@ -3084,8 +3043,8 @@ addBtn.addEventListener('click', () => {
     const item = {
       id: genId('floor'),
       type,
-      x: snapValue(state.Wmm / 2),
-      y: snapValue(state.Lmm / 2),
+      x: snapValue(state.Wmm / 2, state.snap),
+      y: snapValue(state.Lmm / 2, state.snap),
       w: def.w,
       l: def.l,
       rotation: 0
@@ -3126,7 +3085,7 @@ addDoorBtn.addEventListener('click', () => {
   const door = {
     id: genId('door'),
     wall: geom.ref,
-    offset: snapValue(maxOffset / 2),
+    offset: snapValue(maxOffset / 2, state.snap),
     width,
     thickness: DOOR_DEFAULT_THICKNESS
   };
@@ -3222,20 +3181,6 @@ const CABLE_SAMPLE_SEGMENTS = 48;
 const GROUND_Z_MM = 0;
 const CABLE_DROP_FRACTION = 0.2;
 const CABLE_DROP_MAX_MM = 450;
-const WALL_ITEM_CONTROLS_TEMPLATE = `
-      <div class="panel" id="wallItemControls">
-        <h3>Wall Item Details</h3>
-        <div class="note" id="wallItemSelectionNote">Select a wall-mounted item to edit its mount height.</div>
-        <label>
-          Adjust mount height
-          <input type="range" id="wallItemMountHeightSlider" min="0" max="${DEFAULT_ROOM_HEIGHT_MM}" step="10" disabled>
-        </label>
-        <label>
-          Mount height (mm)
-          <input type="number" id="wallItemMountHeight" min="0" max="${DEFAULT_ROOM_HEIGHT_MM}" step="10" disabled>
-        </label>
-      </div>
-`;
 const CABLE_CONTROLS_TEMPLATE = `
       <div class="panel" id="cableControls">
         <h3>Service Cables</h3>
@@ -3252,10 +3197,6 @@ const CABLE_CONTROLS_TEMPLATE = `
       </div>
 `;
 
-let wallItemControlsEl = null;
-let wallItemMountInputEl = null;
-let wallItemMountSliderEl = null;
-let wallItemSelectionNoteEl = null;
 let cableTypeSelectEl = null;
 let cancelCableBtnEl = null;
 let deleteCableBtnEl = null;
@@ -3960,7 +3901,7 @@ function renderCables() {
       setSelectedSurface({ type: 'cable', id: cable.id });
       const pt = svgPoint(evt);
       const roomPt = svgPointToRoomMm(pt);
-      const snapped = snapPoint(clampPointToRoom(roomPt));
+      const snapped = snapPoint(clampPointToRoom(roomPt), state.snap);
       if (insertCableBendPoint(cable, snapped)) {
         evt.stopPropagation();
         evt.preventDefault();
@@ -4020,7 +3961,7 @@ function insertCableBendPoint(cable, approxPoint) {
   const start = resolveSocketPosition(cable.source);
   const end = resolveSocketPosition(cable.target);
   if (!start || !end) return false;
-  const snapped = snapPoint(approxPoint);
+  const snapped = snapPoint(approxPoint, state.snap);
   const rawPoint = snapped;
   let insertIndex = Array.isArray(cable.bendPoints) ? cable.bendPoints.length : 0;
   let finalPoint = {
@@ -4054,7 +3995,7 @@ function insertCableBendPoint(cable, approxPoint) {
       };
     }
   }
-  const snappedFinal = snapPoint(finalPoint);
+  const snappedFinal = snapPoint(finalPoint, state.snap);
   const bendPoint = {
     x: snappedFinal.x,
     y: snappedFinal.y,
@@ -4067,37 +4008,6 @@ function insertCableBendPoint(cable, approxPoint) {
   showHud('Added bend point.');
   return true;
 }
-
- (function setupWallItemControls() {
-  const aside = document.querySelector('aside');
-  if (!aside) return;
-  aside.insertAdjacentHTML('beforeend', WALL_ITEM_CONTROLS_TEMPLATE);
-  wallItemControlsEl = document.getElementById('wallItemControls');
-  wallItemMountInputEl = document.getElementById('wallItemMountHeight');
-  wallItemMountSliderEl = document.getElementById('wallItemMountHeightSlider');
-  wallItemSelectionNoteEl = document.getElementById('wallItemSelectionNote');
-  if (wallItemMountSliderEl) {
-    wallItemMountSliderEl.addEventListener('input', evt => {
-      const value = Number(evt.target.value);
-      if (!Number.isFinite(value)) return;
-      if (wallItemMountInputEl) {
-        wallItemMountInputEl.value = `${Math.round(value)}`;
-      }
-      applySelectedWallItemMountHeight(value);
-    });
-  }
-  if (wallItemMountInputEl) {
-    wallItemMountInputEl.addEventListener('change', evt => {
-      const value = Number(evt.target.value);
-      if (!Number.isFinite(value)) return;
-      if (wallItemMountSliderEl) {
-        wallItemMountSliderEl.value = `${Math.round(value)}`;
-      }
-      applySelectedWallItemMountHeight(value);
-    });
-  }
-  updateWallItemControls();
-})();
 
 (function setupCablePrototype() {
   const aside = document.querySelector('aside');
@@ -4255,7 +4165,7 @@ function insertCableBendPoint(cable, approxPoint) {
     const roomPt = drag.kind === 'cable-handle' || drag.kind === 'cable-bend'
       ? rawRoomPt
       : clampPointToRoom(rawRoomPt);
-    const snapped = snapPoint(roomPt);
+    const snapped = snapPoint(roomPt, state.snap);
     if (drag.kind === 'cable-handle') {
       const handle = cable.controlPoints[drag.handleIndex];
       if (!handle) return;

--- a/tests/js/test_wall_drag_snap.mjs
+++ b/tests/js/test_wall_drag_snap.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { applyDragSnap, snapPoint, snapValue } from '../../dev/room_survey_min/drag_snap.js';
+
+const SNAP = 100;
+
+{
+  const value = snapValue(1437, SNAP);
+  assert.equal(value, 1400);
+}
+
+{
+  const point = snapPoint({ x: 1437, y: 286 }, SNAP);
+  assert.deepEqual(point, { x: 1400, y: 300 });
+}
+
+{
+  const result = applyDragSnap({
+    pointer: { x: 612, y: 1478 },
+    offsets: { x: 12, y: 28 },
+    snap: SNAP,
+    limits: { minX: 0, maxX: 4000, minY: 0, maxY: 3000 },
+  });
+  assert.deepEqual(result, { x: 600, y: 1500 });
+}
+
+{
+  const result = applyDragSnap({
+    pointer: { x: -120, y: 4120 },
+    offsets: { x: 0, y: 0 },
+    snap: SNAP,
+    limits: { minX: 0, maxX: 2500, minY: 0, maxY: 3000 },
+  });
+  assert.deepEqual(result, { x: 0, y: 3000 });
+}
+
+{
+  const raw = applyDragSnap({
+    pointer: { x: 512.5, y: 612.5 },
+    offsets: { x: 12.5, y: 12.5 },
+    snap: 0,
+    limits: { minX: 0, maxX: 1000, minY: 0, maxY: 1000 },
+  });
+  assert.deepEqual(raw, { x: 500, y: 600 });
+}

--- a/tests/test_frontend_markup.py
+++ b/tests/test_frontend_markup.py
@@ -181,6 +181,24 @@ def test_room_survey_provides_wall_elevation_and_scale_overlay() -> None:
     assert "const SCALE_OVERLAY_CONFIG" in html
 
 
+def test_room_survey_imports_shared_drag_snap_pipeline() -> None:
+    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "from './drag_snap.js'" in html
+    assert "applyDragSnap({" in html
+
+
+def test_room_survey_hides_legacy_wall_height_controls() -> None:
+    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'id="wallItemControls"' not in html
+    assert "Wall Item Details" not in html
+
+
 def test_room_survey_inventory_table_with_fit_checks() -> None:
     html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
         encoding="utf-8"
@@ -200,7 +218,8 @@ def test_wall_elevation_uses_shared_snap_drag_pipeline() -> None:
 
     assert "function handleWallElevationDragStart" in html
     assert "drag.kind === 'wall-elevation-item'" in html
-    assert "snapValue(roomPt.x - drag.offsetX)" in html
+    assert "applyDragSnap({" in html
+    assert "item.mountHeight_mm = snapped.y" in html
 
 
 def test_room_survey_updates_svg_orientation_attribute() -> None:
@@ -250,17 +269,6 @@ def test_fps_viewer_imports_shared_movement_controller() -> None:
     assert "fpv_movement_controller.js" in html
     assert "createMovementController" in html
     assert "movementController.step" in html
-
-
-def test_room_survey_exposes_wall_mount_height_controls() -> None:
-    html = Path("dev/room_survey_min/room_survey_min_v1.html").read_text(
-        encoding="utf-8"
-    )
-
-    assert 'id="wallItemControls"' in html
-    assert 'id="wallItemMountHeight"' in html
-    assert 'id="wallItemMountHeightSlider"' in html
-    assert "function updateWallItemControls" in html
 
 
 def test_room_survey_exports_unclamped_cable_points() -> None:

--- a/tests/test_node_modules.py
+++ b/tests/test_node_modules.py
@@ -24,3 +24,9 @@ def test_fpv_movement_idle_velocity_zero() -> None:
     script = Path("tests/js/test_fpv_movement_idle.mjs")
     assert script.exists()
     _run_node(script)
+
+
+def test_wall_drag_snap_pipeline() -> None:
+    script = Path("tests/js/test_wall_drag_snap.mjs")
+    assert script.exists()
+    _run_node(script)


### PR DESCRIPTION
## Summary
- introduce a shared drag snap helper and reuse it for floor and wall drags while removing the mount-height panel markup
- update the wall elevation pointer handling to quantize offsets/heights via the shared pipeline and reuse the HUD messaging
- extend markup and node tests to cover the new drag snap module and absence of the legacy wall controls

## Testing
- ruff check .
- black --check .
- mypy .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1878a95bc83298328191cfe12a2aa